### PR TITLE
docs: add unstructure governance docs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,0 +1,147 @@
+version: 1
+layout: repo
+lastReviewedAt: "2026-04-29"
+lastReviewedCommit: "09e5508f5b5391669df252fb67d8ba9a60fbf08e"
+
+repo:
+  id: unstructure
+
+routing:
+  intents:
+    governance:
+      paths:
+        - AGENTS.md
+        - .docpact/**
+        - _docs/**
+    architecture:
+      paths:
+        - src/**
+        - docker/**
+        - requirements.txt
+    operations:
+      paths:
+        - README.md
+        - requirements.txt
+        - docker/**
+        - .vscode/**
+
+coverage:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/**
+    - _docs/**
+    - requirements.txt
+    - src/**
+    - docker/**
+    - .vscode/**
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - .venv/**
+    - __pycache__/**
+    - "**/__pycache__/**"
+    - .pytest_cache/**
+    - .ruff_cache/**
+    - dist/**
+    - build/**
+    - docs/**
+    - processed_docs/**
+    - test/queue/**
+    - logs/**
+    - "*.log"
+    - .DS_Store
+    - "**/.DS_Store"
+
+docInventory:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/config.yaml
+    - _docs/**
+    - src/**/AGENTS.md
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - .venv/**
+    - __pycache__/**
+    - "**/__pycache__/**"
+    - dist/**
+    - build/**
+    - docs/**
+    - processed_docs/**
+    - test/queue/**
+    - logs/**
+
+freshness:
+  warn_after_commits: 50
+  warn_after_days: 90
+  critical_after_days: 180
+
+rules:
+  - id: unstructure-governance
+    scope: repo
+    repo: unstructure
+    triggers:
+      - path: AGENTS.md
+        kind: agent-contract
+      - path: .docpact/config.yaml
+        kind: machine-contract
+      - path: _docs/**
+        kind: governed-docs
+      - path: README.md
+        kind: repo-entry
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: _docs/README.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/standards/documentation-standards.md
+        mode: review_or_update
+    reason: Repository entry guidance, governance config, and documentation standards must remain aligned.
+  - id: unstructure-processing-surface
+    scope: repo
+    repo: unstructure
+    triggers:
+      - path: src/**
+        kind: document-processing-source
+      - path: docker/**
+        kind: local-service-stack
+      - path: requirements.txt
+        kind: python-dependencies
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: src/journals/AGENTS.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+    reason: Processing scripts, dependency facts, and local service stack changes must stay synchronized with architecture and runbook docs.
+  - id: unstructure-operations
+    scope: repo
+    repo: unstructure
+    triggers:
+      - path: README.md
+        kind: developer-guide
+      - path: requirements.txt
+        kind: dependency-lock-lite
+      - path: .vscode/**
+        kind: editor-workflow
+    requiredDocs:
+      - path: README.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+    reason: Setup, dependency, editor, and operational command changes define how processing jobs are run.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -12,6 +12,7 @@ routing:
       paths:
         - AGENTS.md
         - .docpact/**
+        - .github/workflows/docpact.yml
         - _docs/**
     architecture:
       paths:
@@ -30,6 +31,7 @@ coverage:
     - AGENTS.md
     - README.md
     - .docpact/**
+    - .github/workflows/docpact.yml
     - _docs/**
     - requirements.txt
     - src/**
@@ -87,6 +89,8 @@ rules:
         kind: agent-contract
       - path: .docpact/config.yaml
         kind: machine-contract
+      - path: .github/workflows/docpact.yml
+        kind: governance-ci
       - path: _docs/**
         kind: governed-docs
       - path: README.md

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -1,0 +1,40 @@
+name: docpact
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            validate-config
+            --root .
+            --strict
+
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            lint
+            --root .
+            --base ${{ github.event.pull_request.base.sha }}
+            --head ${{ github.sha }}
+            --mode enforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+---
+docType: agent-contract
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "Before editing the unstructure repository."
+whenToUpdate: "When repo entry points, workflow commands, docpact config, document processing domains, or deployment boundaries change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# TianGong AI Unstructure Agent Contract
+
+This repository owns document unstructure and chunking workflows for TianGong AI
+knowledge sources. Workspace-level submodule policy remains in the root
+workspace; product implementation and repo-local documentation belong here.
+
+## Required Load Order
+
+1. Read this file.
+2. Read `.docpact/config.yaml`.
+3. Run `docpact route --root . --paths <target-paths> --format json` from this
+   repo root for the files you plan to change.
+4. Read the relevant files under `_docs/contracts/**`, `_docs/architecture/**`,
+   and `_docs/runbooks/**`.
+5. If the target is under `src/journals/**`, also read
+   `src/journals/AGENTS.md`.
+6. Read the implementation files under `src/**` or `docker/**`.
+
+## Source Of Truth
+
+- `.docpact/config.yaml`: machine-readable governance rules, routing aliases,
+  coverage, document inventory, and freshness policy.
+- `README.md`: legacy setup notes and uncurated operational examples; verify
+  command paths against `src/**` before running.
+- `_docs/runbooks/development.md`: curated setup, validation, and operation
+  workflow.
+- `_docs/contracts/repo-contract.md`: durable ownership and boundary rules.
+- `_docs/architecture/repo-architecture.md`: current processing topology and
+  key paths.
+
+## Hard Boundaries
+
+- Do not move workspace submodule policy, branch policy, or integration
+  completion rules into this repository.
+- Do not commit local credentials, downloaded source documents, generated
+  processed outputs, or long-running job logs.
+- Treat source-specific processing scripts under `src/**` as data pipeline
+  behavior; update architecture or runbook docs when inputs, outputs, indexes,
+  model dependencies, or operational commands change.
+
+## Completion Criteria
+
+- Relevant docpact route output has been reviewed before code or docs changes.
+- Docs touched by the route result are reviewed or updated.
+- `docpact validate-config --root . --strict` passes after governance changes.
+- For implementation changes, run the relevant script, dependency, or smoke
+  validation described in `_docs/runbooks/development.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repo entry points, workflow commands, docpact config, docume
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+---
+docType: guide
+scope: repo
+status: legacy
+authoritative: false
+owner: unstructure
+language: en
+whenToUse: "When checking legacy setup notes; verify commands against current files before running."
+whenToUpdate: "When curating or deleting legacy setup and operation notes. Authoritative operation guidance belongs in AGENTS.md and _docs/runbooks/development.md."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - requirements.txt
+  - src/**
+  - docker/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
 
 # TianGong AI Unstructure
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repository documentation layers, key docs, or governance rou
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
@@ -23,6 +24,8 @@ This directory contains the repo-local source documents governed by docpact.
 
 - Layer 0: `AGENTS.md` for mandatory agent entry guidance.
 - Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- CI: `.github/workflows/docpact.yml` for config validation and PR
+  documentation lint.
 - Layer 2: current contracts, architecture, standards, and runbooks under
   `_docs/**`.
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -1,0 +1,35 @@
+---
+docType: index
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "When navigating unstructure repository documentation."
+whenToUpdate: "When repository documentation layers, key docs, or governance routing change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# Unstructure Documentation
+
+This directory contains the repo-local source documents governed by docpact.
+
+## Layers
+
+- Layer 0: `AGENTS.md` for mandatory agent entry guidance.
+- Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- Layer 2: current contracts, architecture, standards, and runbooks under
+  `_docs/**`.
+
+## Current Documents
+
+- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and
+  completion rules.
+- `_docs/architecture/repo-architecture.md`: document processing topology.
+- `_docs/runbooks/development.md`: setup, validation, and operation workflow.
+- `_docs/standards/documentation-standards.md`: repo-local documentation rules.

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -1,0 +1,48 @@
+---
+docType: architecture
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "When changing document processing scripts, dependencies, or local service stack files."
+whenToUpdate: "When source domains, data flow, index targets, OCR/model dependencies, or runtime assumptions change."
+checkPaths:
+  - src/**
+  - docker/**
+  - requirements.txt
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# Unstructure Architecture
+
+## Overview
+
+The repository contains Python workflows for converting heterogeneous source
+documents into structured chunks and index-ready artifacts for TianGong AI.
+Workflows are organized by source domain under `src/**`.
+
+## Key Paths
+
+- `src/{ali,education,edu_textbooks,esg,journals,patents,pptx,reports,standards}/**`:
+  source-domain processing scripts.
+- `src/journals/**`: journal workflows; also read `src/journals/AGENTS.md`.
+- `src/tools/**` and per-domain `tools/**`: helper modules.
+- `src/weaviate/**`: local Weaviate utility scripts.
+- `src/legacy/**`: legacy experiments and migration references; verify before reuse.
+- `docker/weaviate/*.yml`: local Weaviate stacks.
+- `requirements.txt`: Python dependency facts.
+
+## Runtime Shape
+
+The repository expects Python virtual environments and native document tooling
+such as poppler, libreoffice, pandoc, tesseract, and CUDA-capable optional
+components for some workloads. Treat README command dumps as legacy notes unless
+the referenced files still exist.
+
+## Integration Points
+
+- Output artifacts feed downstream knowledge-base and search/index services.
+- Edge functions query indexes or storage populated by these workflows, but API
+  serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -1,0 +1,56 @@
+---
+docType: contract
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "When deciding whether a change belongs in the unstructure repository."
+whenToUpdate: "When ownership, processing boundaries, dependency expectations, or completion criteria change."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - .docpact/config.yaml
+  - src/**
+  - requirements.txt
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# Unstructure Repository Contract
+
+## Ownership
+
+This repository owns document parsing, chunking, and unstructured processing
+scripts for TianGong AI source domains, including ESG, education, journals,
+patents, reports, standards, textbooks, and related vector/index preparation
+flows.
+
+## Boundaries
+
+- API serving belongs in the edge-function repository unless the change is a
+  local processing script here.
+- MCP client-facing tool schemas belong in the MCP repository.
+- Root workspace governance, branch policy, and submodule integration remain in
+  the workspace repository.
+- Large input documents, processed outputs, and job logs are operational data,
+  not source documentation.
+
+## Processing Surface
+
+Scripts under `src/**`, dependency facts in `requirements.txt`, and local stack
+files under `docker/**` define processing behavior. Changes to input formats,
+output locations, chunking logic, embedding/index targets, OCR dependencies, or
+long-running job commands require review of:
+
+- `README.md`
+- `_docs/architecture/repo-architecture.md`
+- `_docs/runbooks/development.md`
+
+## Completion Criteria
+
+- Run `docpact route` before editing governed files.
+- Run `docpact validate-config --root . --strict` after governance changes.
+- For script changes, run the smallest representative script or import/syntax
+  smoke check available for the touched domain.
+- Do not leave dependency, data-flow, or validation facts only in chat.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -1,0 +1,53 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "When developing, validating, or operating unstructure processing workflows."
+whenToUpdate: "When setup commands, dependencies, long-running job commands, or validation steps change."
+checkPaths:
+  - README.md
+  - requirements.txt
+  - src/**
+  - docker/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# Unstructure Development Runbook
+
+## Setup
+
+1. Create and activate a Python virtual environment, typically Python 3.12.
+2. Install dependencies from `requirements.txt`.
+3. Install native tooling required by the target workflow, such as
+   `libmagic-dev`, `poppler-utils`, `libreoffice`, `pandoc`, and OCR
+   dependencies.
+4. Configure any cloud, vector database, or model provider credentials through
+   local environment files; do not commit secrets.
+
+## Validation
+
+Run:
+
+```bash
+docpact validate-config --root . --strict
+```
+
+For Python script changes, run the smallest representative command for the
+touched domain, or at minimum a syntax/import smoke check against the changed
+script in the active virtual environment.
+
+## Long-Running Jobs
+
+Use current script paths confirmed with `rg --files src` before starting
+long-running jobs. Treat README background commands as legacy notes unless the
+referenced path exists.
+
+## Documentation Updates
+
+Update `_docs/architecture/repo-architecture.md` when a source domain,
+processing stage, output target, or dependency class changes. Update this
+runbook when setup, validation, or job operation steps change.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -1,0 +1,39 @@
+---
+docType: standard
+scope: repo
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "When creating, moving, or reviewing unstructure repository documentation."
+whenToUpdate: "When documentation layers, metadata rules, or source-of-truth boundaries change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
+
+# Unstructure Documentation Standards
+
+## Layers
+
+- `AGENTS.md`: mandatory repo entry guidance for agents.
+- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
+  document inventory.
+- `_docs/contracts/**`: current constraints and ownership rules.
+- `_docs/architecture/**`: current processing topology and integration facts.
+- `_docs/runbooks/**`: executable procedures.
+- `_docs/standards/**`: repo-local documentation and engineering standards.
+
+## Rules
+
+- Keep deterministic governance facts in `.docpact/config.yaml`.
+- Keep explanatory processing, dependency, and workflow details in `_docs/**`.
+- Update docs when source domains, processing stages, output locations, index
+  targets, native dependencies, or long-running job commands change.
+- Do not document secrets, local data paths containing private data, or
+  generated output inventories as governed source facts.
+- Do not duplicate root workspace branch policy or submodule integration policy
+  in this repository.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -10,6 +10,7 @@ whenToUpdate: "When documentation layers, metadata rules, or source-of-truth bou
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
@@ -22,6 +23,8 @@ lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
 - `AGENTS.md`: mandatory repo entry guidance for agents.
 - `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
   document inventory.
+- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR
+  documentation lint.
 - `_docs/contracts/**`: current constraints and ownership rules.
 - `_docs/architecture/**`: current processing topology and integration facts.
 - `_docs/runbooks/**`: executable procedures.

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -1,31 +1,28 @@
-# Journal Pickle Queue Agent 使用说明
+---
+docType: agent-note
+scope: module
+status: current
+authoritative: true
+owner: unstructure
+language: en
+whenToUse: "Before editing journal-specific unstructure scripts."
+whenToUpdate: "When journal processing scripts, environment variables, queue behavior, or output paths change."
+checkPaths:
+  - src/journals/**
+  - _docs/architecture/repo-architecture.md
+  - _docs/runbooks/development.md
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+---
 
-## 作用
-- 读取单个元数据 pkl（默认 `part1_journals.pkl`），调用 unstructure 服务生成对应的 pickle，成功后更新数据库 upload_time，失败写入错误 CSV。
-- 通过线程+队列控制并发，默认指向单一服务 `http://localhost:7770/mineru_sci`（服务自身有 4 个 worker）。
+# Journals Agent Notes
 
-## 前置
-- 环境变量：`TOKEN`、`POSTGRES_DB`、`POSTGRES_USER`、`POSTGRES_PASSWORD`、`POSTGRES_HOST`、`POSTGRES_PORT`。
-- 目录：PDF 放在 `docs/journals/`；输出 pickle 在 `docs/processed_docs/journal_new_pickle`（脚本会自动创建）。
-- 元数据：默认 `part1_journals.pkl`，可换成其他 pkl。
-
-## 运行
-- 默认参数：  
-  `python src/journals/file_to_pickle_queue.py`
-- 自定义参数：  
-  - `--service-url` 指定服务地址（默认 `http://localhost:7770/mineru_sci`）  
-  - `--workers` 线程数，默认 4  
-  - `--input` 单个元数据 pkl（默认 `part1_journals.pkl`）  
-  - `--error-file` 失败 ID 的 CSV（默认 `error_file_id_1.csv`）  
-  - `--output-dir` 输出 pickle 的目录（默认 `docs/processed_docs/journal_new_pickle`）
-  
-  示例：`python src/journals/file_to_pickle_queue.py --workers 4 --input part2_journals.pkl --error-file error_file_id_2.csv --output-dir test/queue`
-
-## 记录与失败重试
-- 日志：`journal_queue.log`。
-- 失败 ID：追加到 error CSV（线程安全），下次运行会自动跳过这些失败 ID。
-- 已有 pickle 会跳过，不再请求服务。
-
-## 其他
-- 需要停止旧的多进程脚本时，可自行 `pkill -f "file_to_pickle*.py"` 后再启动本队列脚本。
-pkill -f "file_to_pickle_queue.py"
+- Read the target script before changing journal processing behavior.
+- Legacy pickle scripts: `src/journals/file_to_pickle.py` and
+  `src/journals/file_to_pickle1.py` through `file_to_pickle4.py`.
+- Two-stage queue scripts: `src/journals/two_stage_enqueue.py` and
+  `src/journals/two_stage_enqueue_urgent.py`.
+- Legacy pickle scripts use `TOKEN` plus PostgreSQL env vars. Two-stage scripts
+  use `FASTAPI_BEARER_TOKEN` plus optional `TWO_STAGE_*` env vars.
+- Outputs include `docs/processed_docs/journal_new_pickle`,
+  `journal_pickle_queue`, and script-specific log/error files.


### PR DESCRIPTION
Closes: N/A

## Summary
- Add repo-local docpact config, AGENTS contract, and governed _docs structure.
- Downgrade stale README command dumps to legacy guidance and add current journal notes.

## Key Decisions
- Treat README operational examples as legacy unless paths are verified.
- Keep journal-specific agent guidance in src/journals/AGENTS.md with review metadata.

## Validation
- docpact validate-config --root TianGong-AI-Unstructure --strict --format json
- docpact coverage --root TianGong-AI-Unstructure --format json
- docpact lint --root TianGong-AI-Unstructure --files AGENTS.md,README.md,.docpact/config.yaml,_docs/README.md,_docs/architecture/repo-architecture.md,_docs/runbooks/development.md,_docs/contracts/repo-contract.md,_docs/standards/documentation-standards.md,src/journals/AGENTS.md --format json

## Risks / Rollback
- Documentation-only change; rollback by reverting this PR.

## Follow-ups
- None.

## Workspace Integration
- Requires root workspace submodule pin update after merge.