### PR TITLE
[codex] add KB parse worker MVP

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-29"
-lastReviewedCommit: "09e5508f5b5391669df252fb67d8ba9a60fbf08e"
+lastReviewedAt: "2026-05-05"
+lastReviewedCommit: "f04e08fbe75d92c5ec518e8f043cdd2045c67bcd"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Unstructure Architecture
@@ -27,6 +27,9 @@ Workflows are organized by source domain under `src/**`.
 
 - `src/{ali,education,edu_textbooks,esg,journals,patents,pptx,reports,standards}/**`:
   source-domain processing scripts.
+- `src/kb_parse_worker/**`: KB F03 parse worker that consumes
+  `kb_parse_queue`, claims jobs through the KB control plane, calls
+  Unstructure-Serve, and publishes processed artifacts.
 - `src/journals/**`: journal workflows; also read `src/journals/AGENTS.md`.
 - `src/tools/**` and per-domain `tools/**`: helper modules.
 - `src/weaviate/**`: local Weaviate utility scripts.
@@ -44,5 +47,9 @@ the referenced files still exist.
 ## Integration Points
 
 - Output artifacts feed downstream knowledge-base and search/index services.
+- The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
+  writes processed `jsonl`/`pkl`/`manifest.json` artifacts under the configured
+  NAS processed root, and marks `processed_s3_ready` through KB RPCs after S3
+  ready checks.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Unstructure Development Runbook
@@ -39,6 +39,41 @@ docpact validate-config --root . --strict
 For Python script changes, run the smallest representative command for the
 touched domain, or at minimum a syntax/import smoke check against the changed
 script in the active virtual environment.
+
+For the KB parse worker, run a syntax smoke check before connecting to live
+queues:
+
+```bash
+python -m compileall src/kb_parse_worker
+```
+
+Run one queue message:
+
+```bash
+python -m src.kb_parse_worker.cli once
+```
+
+Run continuously:
+
+```bash
+python -m src.kb_parse_worker.cli run
+```
+
+Required runtime variables:
+
+```text
+DATABASE_URL or SUPABASE_DB_URL or KB_DATABASE_URL
+or SUPABASE_DB_HOST / SUPABASE_DB_PORT / SUPABASE_DB_NAME /
+SUPABASE_DB_USER / SUPABASE_DB_PASSWORD
+NAS_RAW_ROOT
+NAS_PROCESSED_ROOT
+UNSTRUCTURE_SERVE_URL
+UNSTRUCTURE_SERVE_BEARER_TOKEN
+KB_PROCESSED_S3_BUCKET when KB_PARSE_S3_READY_MODE=check
+```
+
+Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3
+sync is intentionally unavailable.
 
 ## Long-Running Jobs
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Unstructure Documentation Standards

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ psycopg2-binary
 Pyarrow
 PyPDF2
 python-dotenv
+requests
 requests-aws4auth
 tenacity
 tiktoken

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 09e5508f5b5391669df252fb67d8ba9a60fbf08e
+lastReviewedAt: 2026-05-05
+lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/__init__.py
+++ b/src/kb_parse_worker/__init__.py
@@ -1,0 +1,2 @@
+"""KB parse worker package."""
+

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -1,0 +1,87 @@
+"""Write parser results to processed artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .manifest import ArtifactInfo, build_manifest, file_sha256, write_manifest
+from .snapshot import ParseSnapshot
+
+
+def _safe_replace_dir(src: Path, dst: Path) -> None:
+    backup = dst.with_name(f"{dst.name}.previous")
+    if backup.exists():
+        shutil.rmtree(backup)
+    if dst.exists():
+        dst.rename(backup)
+    src.rename(dst)
+    if backup.exists():
+        shutil.rmtree(backup)
+
+
+def write_processed_artifacts(
+    result: list[Any],
+    snapshot: ParseSnapshot,
+    nas_processed_root: Path,
+    parser_profile: str,
+    parser_version: str,
+) -> tuple[Path, ArtifactInfo]:
+    if not result:
+        raise ValueError("EMPTY_RESULT")
+
+    artifact_uuid = str(uuid.uuid4())
+    collection_root = nas_processed_root / snapshot.collection_storage_path
+    tmp_dir = collection_root / ".tmp" / f"{snapshot.job_id}-{artifact_uuid}"
+    final_dir = collection_root / snapshot.document_id
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True, exist_ok=False)
+
+    jsonl_path = tmp_dir / f"{artifact_uuid}.jsonl"
+    pkl_path = tmp_dir / f"{artifact_uuid}.pkl"
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for item in result:
+            handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+    with pkl_path.open("wb") as handle:
+        pickle.dump(result, handle)
+
+    if sum(1 for _ in jsonl_path.open("r", encoding="utf-8")) != len(result):
+        raise RuntimeError("ARTIFACT_VALIDATE_FAILED: jsonl row count mismatch")
+    with pkl_path.open("rb") as handle:
+        pickle.load(handle)
+    if jsonl_path.stat().st_size <= 0 or pkl_path.stat().st_size <= 0:
+        raise RuntimeError("ARTIFACT_VALIDATE_FAILED: empty artifact file")
+
+    manifest, _ = build_manifest(
+        snapshot=snapshot,
+        artifact_uuid=artifact_uuid,
+        chunk_count=len(result),
+        jsonl_path=jsonl_path,
+        pkl_path=pkl_path,
+        parser_profile=parser_profile,
+        parser_version=parser_version,
+    )
+    write_manifest(tmp_dir / "manifest.tmp.json", manifest)
+    os.replace(tmp_dir / "manifest.tmp.json", tmp_dir / "manifest.json")
+    manifest_hash = file_sha256(tmp_dir / "manifest.json")
+
+    _safe_replace_dir(tmp_dir, final_dir)
+    info = ArtifactInfo(
+        artifact_uuid=artifact_uuid,
+        chunk_count=len(result),
+        jsonl_name=jsonl_path.name,
+        pkl_name=pkl_path.name,
+        jsonl_sha256=manifest["sha256"]["chunks_jsonl"],
+        pkl_sha256=manifest["sha256"]["chunks_pkl"],
+        jsonl_size_bytes=manifest["size_bytes"]["chunks_jsonl"],
+        pkl_size_bytes=manifest["size_bytes"]["chunks_pkl"],
+        manifest_hash=manifest_hash,
+        manifest=manifest,
+    )
+    return final_dir, info

--- a/src/kb_parse_worker/cli.py
+++ b/src/kb_parse_worker/cli.py
@@ -1,0 +1,31 @@
+"""Command line entrypoint for the KB parse worker."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .config import WorkerConfig
+from .worker import ParseWorker
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the KB parse worker.")
+    parser.add_argument("mode", choices=("once", "run"), help="Run one queue message or poll forever.")
+    parser.add_argument("--log-level", default="INFO", help="Python logging level.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    worker = ParseWorker(WorkerConfig.from_env())
+    if args.mode == "once":
+        worker.run_once()
+    else:
+        worker.run_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -1,0 +1,105 @@
+"""Runtime configuration for the KB parse worker."""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from dotenv import load_dotenv
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def database_url_from_env() -> str:
+    for name in ("DATABASE_URL", "SUPABASE_DB_URL", "KB_DATABASE_URL"):
+        value = os.getenv(name)
+        if value:
+            return value
+
+    db = os.getenv("POSTGRES_DB") or os.getenv("SUPABASE_DB_NAME")
+    user = os.getenv("POSTGRES_USER") or os.getenv("SUPABASE_DB_USER")
+    password = os.getenv("POSTGRES_PASSWORD") or os.getenv("SUPABASE_DB_PASSWORD")
+    host = os.getenv("POSTGRES_HOST") or os.getenv("SUPABASE_DB_HOST") or "localhost"
+    port = os.getenv("POSTGRES_PORT") or os.getenv("SUPABASE_DB_PORT") or "5432"
+    if not db or not user or password is None:
+        raise ValueError(
+            "Set DATABASE_URL/SUPABASE_DB_URL/KB_DATABASE_URL or POSTGRES_DB, "
+            "POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT. "
+            "SUPABASE_DB_NAME, SUPABASE_DB_USER, SUPABASE_DB_PASSWORD, "
+            "SUPABASE_DB_HOST, SUPABASE_DB_PORT are also supported."
+        )
+    return (
+        f"postgresql://{quote_plus(user)}:{quote_plus(password)}"
+        f"@{host}:{port}/{quote_plus(db)}"
+    )
+
+
+@dataclass(frozen=True)
+class WorkerConfig:
+    database_url: str
+    worker_id: str
+    queue_name: str
+    queue_vt_seconds: int
+    lock_seconds: int
+    poll_interval_seconds: int
+    nas_raw_root: Path
+    nas_processed_root: Path
+    unstructure_serve_url: str
+    unstructure_serve_bearer_token: str
+    parser_profile: str
+    parser_version: str
+    s3_ready_mode: str
+    s3_bucket: str | None
+    s3_processed_prefix: str
+    s3_strict_hash: bool
+
+    @classmethod
+    def from_env(cls) -> "WorkerConfig":
+        load_dotenv()
+        worker_id = os.getenv("KB_PARSE_WORKER_ID") or f"{socket.gethostname()}-{os.getpid()}"
+        unstructure_url = os.getenv("UNSTRUCTURE_SERVE_URL")
+        token = os.getenv("UNSTRUCTURE_SERVE_BEARER_TOKEN")
+        nas_raw_root = os.getenv("NAS_RAW_ROOT")
+        nas_processed_root = os.getenv("NAS_PROCESSED_ROOT")
+        if not unstructure_url:
+            raise ValueError("UNSTRUCTURE_SERVE_URL is required.")
+        if not token:
+            raise ValueError("UNSTRUCTURE_SERVE_BEARER_TOKEN is required.")
+        if not nas_raw_root:
+            raise ValueError("NAS_RAW_ROOT is required.")
+        if not nas_processed_root:
+            raise ValueError("NAS_PROCESSED_ROOT is required.")
+
+        return cls(
+            database_url=database_url_from_env(),
+            worker_id=worker_id,
+            queue_name=os.getenv("KB_PARSE_QUEUE", "kb_parse_queue"),
+            queue_vt_seconds=_int_env("KB_PARSE_QUEUE_VT_SECONDS", 1800),
+            lock_seconds=_int_env("KB_PARSE_LOCK_SECONDS", 1800),
+            poll_interval_seconds=_int_env("KB_PARSE_POLL_INTERVAL_SECONDS", 5),
+            nas_raw_root=Path(nas_raw_root),
+            nas_processed_root=Path(nas_processed_root),
+            unstructure_serve_url=unstructure_url,
+            unstructure_serve_bearer_token=token,
+            parser_profile=os.getenv("KB_PARSE_PARSER_PROFILE", "mineru_with_images"),
+            parser_version=os.getenv("KB_PARSE_PARSER_VERSION", "unstructure-serve"),
+            s3_ready_mode=os.getenv("KB_PARSE_S3_READY_MODE", "check"),
+            s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET"),
+            s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed"),
+            s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
+        )

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -1,0 +1,120 @@
+"""Supabase/Postgres control-plane RPC calls for parse jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import psycopg2
+import psycopg2.extras
+
+
+@dataclass(frozen=True)
+class ClaimedJob:
+    job_id: str
+    document_id: str
+    document_version: int
+    stage: str
+    status: str
+    payload_json: dict
+
+
+def connect(database_url: str):
+    return psycopg2.connect(database_url)
+
+
+def claim_job(
+    conn,
+    job_id: str,
+    queue_name: str,
+    msg_id: int,
+    worker_id: str,
+    lock_seconds: int,
+) -> ClaimedJob | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select *
+            from public.start_job_from_pgmq_message(%s, %s, %s, %s, %s)
+            """,
+            (job_id, queue_name, msg_id, worker_id, lock_seconds),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    return ClaimedJob(
+        job_id=str(row["job_id"]),
+        document_id=str(row["document_id"]),
+        document_version=int(row["document_version"]),
+        stage=str(row["stage"]),
+        status=str(row["status"]),
+        payload_json=dict(row["payload_json"] or {}),
+    )
+
+
+def heartbeat_job(
+    conn,
+    job_id: str,
+    worker_id: str,
+    lock_seconds: int,
+    vt_seconds: int | None = None,
+) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select public.heartbeat_job(%s, %s, %s, %s)",
+            (job_id, worker_id, lock_seconds, vt_seconds),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
+
+
+def fail_job(
+    conn,
+    job_id: str,
+    worker_id: str,
+    retryable: bool,
+    error: str,
+    error_stage: str = "parse",
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select * from public.fail_job(%s, %s, %s, %s, %s)",
+            (job_id, worker_id, retryable, error[:2000], error_stage),
+        )
+    conn.commit()
+
+
+def mark_processed_s3_ready(
+    conn,
+    job_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_s3_key: str,
+    manifest_hash: str,
+    artifact_uuid: str,
+    manifest_local_uri: str,
+    chunk_count: int,
+) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            select public.mark_processed_s3_ready(
+              %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                document_id,
+                document_version,
+                manifest_s3_key,
+                manifest_hash,
+                artifact_uuid,
+                manifest_local_uri,
+                chunk_count,
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
+

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -1,0 +1,82 @@
+"""Manifest creation and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .snapshot import ParseSnapshot
+
+
+@dataclass(frozen=True)
+class ArtifactInfo:
+    artifact_uuid: str
+    chunk_count: int
+    jsonl_name: str
+    pkl_name: str
+    jsonl_sha256: str
+    pkl_sha256: str
+    jsonl_size_bytes: int
+    pkl_size_bytes: int
+    manifest_hash: str
+    manifest: dict[str, Any]
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def build_manifest(
+    snapshot: ParseSnapshot,
+    artifact_uuid: str,
+    chunk_count: int,
+    jsonl_path: Path,
+    pkl_path: Path,
+    parser_profile: str,
+    parser_version: str,
+) -> tuple[dict[str, Any], str]:
+    jsonl_name = jsonl_path.name
+    pkl_name = pkl_path.name
+    manifest = {
+        "document_id": snapshot.document_id,
+        "document_version": snapshot.document_version,
+        "artifact_uuid": artifact_uuid,
+        "collection_id": snapshot.primary_collection_id,
+        "collection_path": snapshot.collection_path,
+        "collection_storage_path": snapshot.collection_storage_path,
+        "chunk_count": chunk_count,
+        "artifacts": {
+            "chunks_jsonl": jsonl_name,
+            "chunks_pkl": pkl_name,
+        },
+        "sha256": {
+            "chunks_jsonl": file_sha256(jsonl_path),
+            "chunks_pkl": file_sha256(pkl_path),
+        },
+        "size_bytes": {
+            "chunks_jsonl": jsonl_path.stat().st_size,
+            "chunks_pkl": pkl_path.stat().st_size,
+        },
+        "created_at": datetime.now(UTC).isoformat(),
+        "producer": "kb-parse-worker",
+        "parser_profile": parser_profile,
+        "parser_version": parser_version,
+    }
+    manifest_bytes = json.dumps(manifest, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return manifest, hashlib.sha256(manifest_bytes).hexdigest()
+
+
+def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+

--- a/src/kb_parse_worker/parser_adapter.py
+++ b/src/kb_parse_worker/parser_adapter.py
@@ -1,0 +1,41 @@
+"""HTTP adapter for Unstructure-Serve /mineru_with_images."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+class ParserError(RuntimeError):
+    pass
+
+
+def parse_with_unstructure_serve(
+    raw_path: Path,
+    api_url: str,
+    bearer_token: str,
+    timeout_seconds: int = 3600,
+) -> list[Any]:
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    with raw_path.open("rb") as handle:
+        response = requests.post(
+            api_url,
+            files={"file": (raw_path.name, handle)},
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise ParserError(f"parser http error {response.status_code}: {response.text[:500]}") from exc
+
+    payload = response.json()
+    if "result" not in payload:
+        raise ParserError("parser response missing result")
+    result = payload["result"]
+    if not isinstance(result, list):
+        raise ParserError("parser result must be a list")
+    return result
+

--- a/src/kb_parse_worker/queue.py
+++ b/src/kb_parse_worker/queue.py
@@ -1,0 +1,41 @@
+"""PGMQ transport helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class QueueMessage:
+    msg_id: int
+    job_id: str
+    raw_payload: dict[str, Any]
+
+
+def read_one(conn, queue_name: str, vt_seconds: int) -> QueueMessage | None:
+    with conn.cursor() as cur:
+        cur.execute("select msg_id, message from pgmq.read(%s, %s, 1)", (queue_name, vt_seconds))
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    msg_id, message = row
+    if isinstance(message, str):
+        payload = json.loads(message)
+    else:
+        payload = dict(message)
+    job_id = payload.get("job_id")
+    if not job_id:
+        raise ValueError(f"Queue message {msg_id} has no job_id.")
+    return QueueMessage(msg_id=int(msg_id), job_id=str(job_id), raw_payload=payload)
+
+
+def archive_job_message(conn, job_id: str, worker_id: str | None = None) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("select public.archive_job_message(%s, %s)", (job_id, worker_id))
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
+

--- a/src/kb_parse_worker/s3_ready.py
+++ b/src/kb_parse_worker/s3_ready.py
@@ -1,0 +1,62 @@
+"""S3 processed artifact ready checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+import boto3
+
+from .manifest import ArtifactInfo
+from .snapshot import ParseSnapshot
+
+
+@dataclass(frozen=True)
+class S3ReadyResult:
+    ready: bool
+    manifest_s3_key: str
+
+
+def processed_manifest_key(prefix: str, snapshot: ParseSnapshot) -> str:
+    clean_prefix = prefix.strip("/")
+    return f"{clean_prefix}/{snapshot.collection_storage_path}/{snapshot.document_id}/manifest.json"
+
+
+def wait_for_s3_processed_ready(
+    snapshot: ParseSnapshot,
+    artifact_info: ArtifactInfo,
+    bucket: str,
+    prefix: str,
+    strict_hash: bool = False,
+) -> S3ReadyResult:
+    client = boto3.client("s3")
+    manifest_key = processed_manifest_key(prefix, snapshot)
+    client.head_object(Bucket=bucket, Key=manifest_key)
+    manifest_obj = client.get_object(Bucket=bucket, Key=manifest_key)
+    manifest = json.loads(manifest_obj["Body"].read().decode("utf-8"))
+
+    expected = artifact_info.manifest
+    for field in ("document_id", "document_version", "artifact_uuid", "collection_path"):
+        if manifest.get(field) != expected.get(field):
+            raise RuntimeError(f"S3_MANIFEST_MISMATCH: {field}")
+    if manifest.get("collection_storage_path") != expected.get("collection_storage_path"):
+        raise RuntimeError("S3_MANIFEST_MISMATCH: collection_storage_path")
+
+    base = "/".join(manifest_key.split("/")[:-1])
+    for artifact_key, artifact_name in manifest["artifacts"].items():
+        object_key = f"{base}/{artifact_name}"
+        head = client.head_object(Bucket=bucket, Key=object_key)
+        expected_size = int(manifest["size_bytes"][artifact_key])
+        if int(head["ContentLength"]) != expected_size:
+            raise RuntimeError(f"S3_ARTIFACT_MISMATCH: {artifact_name} size")
+        if strict_hash:
+            body = client.get_object(Bucket=bucket, Key=object_key)["Body"]
+            digest = hashlib.sha256()
+            for chunk in iter(lambda: body.read(1024 * 1024), b""):
+                digest.update(chunk)
+            if digest.hexdigest() != manifest["sha256"][artifact_key]:
+                raise RuntimeError(f"S3_ARTIFACT_MISMATCH: {artifact_name} sha256")
+
+    return S3ReadyResult(ready=True, manifest_s3_key=manifest_key)
+

--- a/src/kb_parse_worker/snapshot.py
+++ b/src/kb_parse_worker/snapshot.py
@@ -1,0 +1,118 @@
+"""Read-only current-state snapshot for a claimed parse job."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+import psycopg2.extras
+
+
+@dataclass(frozen=True)
+class ParseSnapshot:
+    job_id: str
+    document_id: str
+    document_version: int
+    raw_uri: str
+    raw_storage_region: str | None
+    file_ext: str | None
+    file_size: int | None
+    sha256: str
+    original_filename: str
+    primary_collection_id: str
+    collection_name: str
+    collection_path: str
+    collection_storage_path: str
+    content_type: str | None
+    collection_metadata_schema_json: dict
+    document_metadata_json: dict
+    job_payload_json: dict
+
+
+def collection_storage_path(collection_path: str) -> str:
+    stripped = re.sub(r"/+", "/", collection_path.strip("/"))
+    parts = [part for part in stripped.split("/") if part]
+    if not parts:
+        raise ValueError("collection path cannot resolve to an empty storage path")
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError(f"collection path contains unsafe segment: {collection_path}")
+    return "/".join(parts)
+
+
+def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select
+              j.id as job_id,
+              j.payload_json as job_payload_json,
+              d.id as document_id,
+              d.document_version,
+              d.raw_uri,
+              d.raw_storage_region,
+              d.file_ext,
+              d.file_size,
+              d.sha256,
+              d.original_filename,
+              d.primary_collection_id,
+              d.metadata_json as document_metadata_json,
+              c.name as collection_name,
+              c.path as collection_path,
+              c.content_type,
+              c.metadata_schema_json as collection_metadata_schema_json
+            from public.kb_jobs j
+            join public.kb_documents d on d.id = j.document_id
+            join public.kb_collections c on c.id = d.primary_collection_id
+            where j.id = %s
+              and j.stage = 'parse'
+              and j.status = 'running'
+              and d.deleted_at is null
+              and j.document_version = d.document_version
+            """,
+            (job_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"No runnable parse snapshot for job {job_id}.")
+    if not row["raw_uri"]:
+        raise RuntimeError(f"Document {row['document_id']} has no raw_uri.")
+
+    path = str(row["collection_path"])
+    return ParseSnapshot(
+        job_id=str(row["job_id"]),
+        document_id=str(row["document_id"]),
+        document_version=int(row["document_version"]),
+        raw_uri=str(row["raw_uri"]),
+        raw_storage_region=row["raw_storage_region"],
+        file_ext=row["file_ext"],
+        file_size=row["file_size"],
+        sha256=str(row["sha256"]),
+        original_filename=str(row["original_filename"]),
+        primary_collection_id=str(row["primary_collection_id"]),
+        collection_name=str(row["collection_name"]),
+        collection_path=path,
+        collection_storage_path=collection_storage_path(path),
+        content_type=row["content_type"],
+        collection_metadata_schema_json=dict(row["collection_metadata_schema_json"] or {}),
+        document_metadata_json=dict(row["document_metadata_json"] or {}),
+        job_payload_json=dict(row["job_payload_json"] or {}),
+    )
+
+
+def resolve_raw_path(raw_uri: str, nas_raw_root: Path) -> Path:
+    parsed = urlparse(raw_uri)
+    if parsed.scheme == "":
+        return Path(raw_uri)
+    if parsed.scheme == "file":
+        return Path(unquote(parsed.path))
+    if parsed.scheme == "nas":
+        rel = unquote(parsed.path).lstrip("/")
+        if parsed.netloc and parsed.netloc not in {"kb", "raw"}:
+            rel = f"{parsed.netloc}/{rel}" if rel else parsed.netloc
+        if rel.startswith("raw/"):
+            rel = rel[len("raw/") :]
+        return nas_raw_root / rel
+    raise ValueError(f"Unsupported raw_uri scheme: {parsed.scheme}")
+

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -1,0 +1,133 @@
+"""KB parse worker orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from pathlib import Path
+
+from . import control_plane, queue
+from .artifacts import write_processed_artifacts
+from .config import WorkerConfig
+from .parser_adapter import parse_with_unstructure_serve
+from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
+from .snapshot import load_parse_snapshot, resolve_raw_path
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _validate_raw_file(path: Path, expected_size: int | None, expected_sha256: str) -> None:
+    if not path.exists():
+        raise RuntimeError("RAW_NOT_FOUND")
+    if expected_size is not None and path.stat().st_size != expected_size:
+        raise RuntimeError("RAW_SIZE_MISMATCH")
+    if _sha256(path).lower() != expected_sha256.lower():
+        raise RuntimeError("RAW_HASH_MISMATCH")
+
+
+class ParseWorker:
+    def __init__(self, config: WorkerConfig):
+        self.config = config
+
+    def run_forever(self) -> None:
+        while True:
+            processed = self.run_once()
+            if not processed:
+                time.sleep(self.config.poll_interval_seconds)
+
+    def run_once(self) -> bool:
+        with control_plane.connect(self.config.database_url) as conn:
+            message = queue.read_one(conn, self.config.queue_name, self.config.queue_vt_seconds)
+            if message is None:
+                return False
+            self.process_message(conn, message)
+            return True
+
+    def process_message(self, conn, message: queue.QueueMessage) -> None:
+        claimed = control_plane.claim_job(
+            conn,
+            message.job_id,
+            self.config.queue_name,
+            message.msg_id,
+            self.config.worker_id,
+            self.config.lock_seconds,
+        )
+        if claimed is None:
+            LOGGER.info("job %s was not claimable", message.job_id)
+            queue.archive_job_message(conn, message.job_id, self.config.worker_id)
+            return
+        if claimed.stage != "parse":
+            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, False, "UNSUPPORTED_STAGE")
+            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+            return
+
+        try:
+            control_plane.heartbeat_job(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                self.config.lock_seconds,
+                self.config.queue_vt_seconds,
+            )
+            snapshot = load_parse_snapshot(conn, claimed.job_id)
+            raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
+            _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
+
+            result = parse_with_unstructure_serve(
+                raw_path,
+                self.config.unstructure_serve_url,
+                self.config.unstructure_serve_bearer_token,
+            )
+            final_dir, artifact_info = write_processed_artifacts(
+                result,
+                snapshot,
+                self.config.nas_processed_root,
+                self.config.parser_profile,
+                self.config.parser_version,
+            )
+            manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
+
+            if self.config.s3_ready_mode == "skip":
+                if not self.config.s3_bucket:
+                    manifest_s3_key = processed_manifest_key(self.config.s3_processed_prefix, snapshot)
+                else:
+                    manifest_s3_key = processed_manifest_key(self.config.s3_processed_prefix, snapshot)
+            else:
+                if not self.config.s3_bucket:
+                    raise RuntimeError("S3_NOT_READY: KB_PROCESSED_S3_BUCKET is required")
+                ready = wait_for_s3_processed_ready(
+                    snapshot,
+                    artifact_info,
+                    self.config.s3_bucket,
+                    self.config.s3_processed_prefix,
+                    self.config.s3_strict_hash,
+                )
+                manifest_s3_key = ready.manifest_s3_key
+
+            ok = control_plane.mark_processed_s3_ready(
+                conn,
+                claimed.job_id,
+                claimed.document_id,
+                claimed.document_version,
+                manifest_s3_key,
+                artifact_info.manifest_hash,
+                artifact_info.artifact_uuid,
+                manifest_local_uri,
+                artifact_info.chunk_count,
+            )
+            if not ok:
+                raise RuntimeError("mark_processed_s3_ready returned false")
+            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+        except Exception as exc:
+            LOGGER.exception("parse job %s failed", claimed.job_id)
+            retryable = str(exc) not in {"RAW_HASH_MISMATCH", "EMPTY_RESULT"}
+            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, retryable, str(exc))


### PR DESCRIPTION
## Summary

Adds the initial KB parse worker package under `src/kb_parse_worker/`.

The worker claims `kb_parse_queue` jobs, snapshots `kb_jobs`, `kb_documents`, and `kb_collections`, reads raw artifacts from NAS, calls the configured Unstructure-Serve `/mineru_with_images` endpoint, publishes processed artifacts with an atomic `manifest.json`, optionally gates on processed S3 readiness, and marks the document/job as processed.

## Notable details

- Uses `UNSTRUCTURE_SERVE_URL` for the parser endpoint; local ops currently expects `http://localhost:7770/mineru_with_images`.
- Does not perform chunk normalization for this MVP.
- Supports DB URL envs directly or from `SUPABASE_DB_*` / `POSTGRES_*` parts.
- Adds a CLI entrypoint: `python -m src.kb_parse_worker.cli`.
- Updates repo docs/runbook notes for the worker module.

## Validation

- `python -m compileall src/kb_parse_worker`
- `docpact validate-config --root . --strict --format json`
- `docpact lint --root . --files ... --format json --output .docpact/runs/latest.json`
- `git diff --check`
- Local smoke using a tunneled Unstructure-Serve on `hp-server:7770` with `/tmp/kb_parse_worker_smoke` roots succeeded:
  - document status: `processed_s3_ready`
  - job status: `succeeded`
  - chunk count: `723`

## Follow-ups / risks

- Real NAS paths under `/homes/nanli/docs` were not present on the checked worker host during smoke.
- Synology Drive Client was not found on the checked worker host.
- S3 readiness was not exercised in smoke because `KB_PARSE_S3_READY_MODE=skip` was used.
- Root workspace submodule integration should wait until this PR is merged into the upstream repository.