### PR TITLE
feat: record KB parse local readiness

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-05"
-lastReviewedCommit: "f04e08fbe75d92c5ec518e8f043cdd2045c67bcd"
+lastReviewedCommit: "ebc538d28329917bec10529a038d4553ff6c6135"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - docker/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -49,7 +49,8 @@ the referenced files still exist.
 - Output artifacts feed downstream knowledge-base and search/index services.
 - The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
   writes processed `jsonl`/`pkl`/`manifest.json` artifacts under the configured
-  NAS processed root, and marks `processed_s3_ready` through KB RPCs after S3
-  ready checks.
+  NAS processed root, records parse local-ready through KB RPCs, and marks
+  `processed_s3_ready` through worker-lock-checked KB RPCs after S3 ready
+  checks.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - requirements.txt
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -69,7 +69,16 @@ NAS_RAW_ROOT
 NAS_PROCESSED_ROOT
 UNSTRUCTURE_SERVE_URL
 UNSTRUCTURE_SERVE_BEARER_TOKEN
-KB_PROCESSED_S3_BUCKET when KB_PARSE_S3_READY_MODE=check
+KB_PROCESSED_S3_BUCKET when overriding the default processed bucket
+```
+
+Current workspace design documents point the processed S3 location at bucket
+`tiangong-kb` with prefix `processed`. The worker defaults to those values and
+keeps both overridable through runtime configuration:
+
+```text
+KB_PROCESSED_S3_BUCKET=tiangong-kb
+KB_PROCESSED_S3_PREFIX=processed
 ```
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -12,7 +12,7 @@ checkPaths:
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -99,7 +99,7 @@ class WorkerConfig:
             parser_profile=os.getenv("KB_PARSE_PARSER_PROFILE", "mineru_with_images"),
             parser_version=os.getenv("KB_PARSE_PARSER_VERSION", "unstructure-serve"),
             s3_ready_mode=os.getenv("KB_PARSE_S3_READY_MODE", "check"),
-            s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET"),
+            s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET", "tiangong-kb"),
             s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed"),
             s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
         )

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -85,9 +85,46 @@ def fail_job(
     conn.commit()
 
 
+def mark_parse_local_ready(
+    conn,
+    job_id: str,
+    worker_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_local_uri: str,
+    artifact_uuid: str,
+    manifest_hash: str,
+    chunk_count: int,
+    metadata_json: dict,
+) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            select public.mark_parse_local_ready(
+              %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                worker_id,
+                document_id,
+                document_version,
+                manifest_local_uri,
+                artifact_uuid,
+                manifest_hash,
+                chunk_count,
+                psycopg2.extras.Json(metadata_json),
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
+
+
 def mark_processed_s3_ready(
     conn,
     job_id: str,
+    worker_id: str,
     document_id: str,
     document_version: int,
     manifest_s3_key: str,
@@ -100,11 +137,12 @@ def mark_processed_s3_ready(
         cur.execute(
             """
             select public.mark_processed_s3_ready(
-              %s, %s, %s, %s, %s, %s, %s, %s
+              %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
             (
                 job_id,
+                worker_id,
                 document_id,
                 document_version,
                 manifest_s3_key,
@@ -117,4 +155,3 @@ def mark_processed_s3_ready(
         row = cur.fetchone()
     conn.commit()
     return bool(row and row[0])
-

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -95,6 +95,29 @@ class ParseWorker:
                 self.config.parser_version,
             )
             manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
+            metadata_json = {
+                "processed": {
+                    "parser_profile": self.config.parser_profile,
+                    "parser_version": self.config.parser_version,
+                    "chunk_count": artifact_info.chunk_count,
+                    "artifact_uuid": artifact_info.artifact_uuid,
+                }
+            }
+
+            ok = control_plane.mark_parse_local_ready(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                claimed.document_id,
+                claimed.document_version,
+                manifest_local_uri,
+                artifact_info.artifact_uuid,
+                artifact_info.manifest_hash,
+                artifact_info.chunk_count,
+                metadata_json,
+            )
+            if not ok:
+                raise RuntimeError("mark_parse_local_ready returned false")
 
             if self.config.s3_ready_mode == "skip":
                 if not self.config.s3_bucket:
@@ -116,6 +139,7 @@ class ParseWorker:
             ok = control_plane.mark_processed_s3_ready(
                 conn,
                 claimed.job_id,
+                self.config.worker_id,
                 claimed.document_id,
                 claimed.document_version,
                 manifest_s3_key,


### PR DESCRIPTION
## Summary
- Default KB processed S3 bucket to `tiangong-kb` while keeping `KB_PROCESSED_S3_BUCKET` and `KB_PROCESSED_S3_PREFIX` configurable.
- Add parse-worker RPC adapter for `mark_parse_local_ready(...)`.
- Call local-ready after local artifact publish and before S3 ready gate.
- Pass `worker_id` into `mark_processed_s3_ready(...)` for the new KB worker-lock-checked signature.
- Update repo docs/runbook with the local-ready and S3 processed location contract.

## Validation
- `python3 -m compileall src/kb_parse_worker`
- `docpact validate-config --root . --strict --format json`
- `docpact lint --root . --worktree --format json --output .docpact/runs/latest.json`

## Related
- Workspace F03 tracking: tiangong-ai/workspace#5
- Requires KB migration commit `b14d5aa` on `linancn/TianGong-AI-KB@master`.
