### PR TITLE
fix: align KB processed S3 defaults

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-05"
-lastReviewedCommit: "ebc538d28329917bec10529a038d4553ff6c6135"
+lastReviewedCommit: "d9aa38132146c069372584dc658748e61bb6b551"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - docker/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -12,7 +12,7 @@ checkPaths:
   - docker/**
   - requirements.txt
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # Unstructure Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - requirements.txt
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -72,13 +72,19 @@ UNSTRUCTURE_SERVE_BEARER_TOKEN
 KB_PROCESSED_S3_BUCKET when overriding the default processed bucket
 ```
 
+Current workspace worker deployment points `UNSTRUCTURE_SERVE_URL` at:
+
+```text
+UNSTRUCTURE_SERVE_URL=http://192.168.1.140:7770/mineru_with_images
+```
+
 Current workspace design documents point the processed S3 location at bucket
-`tiangong-kb` with prefix `processed`. The worker defaults to those values and
+`tiangong` with prefix `processed_docs`. The worker defaults to those values and
 keeps both overridable through runtime configuration:
 
 ```text
-KB_PROCESSED_S3_BUCKET=tiangong-kb
-KB_PROCESSED_S3_PREFIX=processed
+KB_PROCESSED_S3_BUCKET=tiangong
+KB_PROCESSED_S3_PREFIX=processed_docs
 ```
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -12,7 +12,7 @@ checkPaths:
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: ebc538d28329917bec10529a038d4553ff6c6135
+lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -99,7 +99,7 @@ class WorkerConfig:
             parser_profile=os.getenv("KB_PARSE_PARSER_PROFILE", "mineru_with_images"),
             parser_version=os.getenv("KB_PARSE_PARSER_VERSION", "unstructure-serve"),
             s3_ready_mode=os.getenv("KB_PARSE_S3_READY_MODE", "check"),
-            s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET", "tiangong-kb"),
-            s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed"),
+            s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET", "tiangong"),
+            s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed_docs"),
             s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
         )


### PR DESCRIPTION
## Summary
- Default KB processed S3 bucket to `tiangong`.
- Default KB processed S3 prefix to `processed_docs`.
- Record current Unstructure-Serve URL `http://192.168.1.140:7770/mineru_with_images` in the repo runbook.
- Refresh docpact review evidence for governed docs touched by the runbook/config change.

## Validation
- `python3 -m compileall TianGong-AI-Unstructure/src/kb_parse_worker`
- `docpact validate-config --root TianGong-AI-Unstructure --strict --format json`
- `docpact lint --root TianGong-AI-Unstructure --worktree --format json --output .docpact/runs/unstructure-latest.json`
- `git -C TianGong-AI-Unstructure diff --check`

## Review
- @ li-nan@tsinghua.edu.cn

## Related
- Workspace F03 tracking: tiangong-ai/workspace#5