### PR TITLE
fix: harden F03 parse worker deployment

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -23,6 +23,7 @@ routing:
       paths:
         - README.md
         - requirements.txt
+        - ecosystem*.json
         - docker/**
         - .vscode/**
 
@@ -33,6 +34,7 @@ coverage:
     - .docpact/**
     - .github/workflows/docpact.yml
     - _docs/**
+    - ecosystem*.json
     - requirements.txt
     - src/**
     - docker/**
@@ -137,6 +139,8 @@ rules:
     triggers:
       - path: README.md
         kind: developer-guide
+      - path: ecosystem*.json
+        kind: process-manager-config
       - path: requirements.txt
         kind: dependency-lock-lite
       - path: .vscode/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - docker/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -30,6 +30,8 @@ Workflows are organized by source domain under `src/**`.
 - `src/kb_parse_worker/**`: KB F03 parse worker that consumes
   `kb_parse_queue`, claims jobs through the KB control plane, calls
   Unstructure-Serve, and publishes processed artifacts.
+- `ecosystem.kb_parse_worker.json`: PM2 process definition for the KB parse
+  worker.
 - `src/journals/**`: journal workflows; also read `src/journals/AGENTS.md`.
 - `src/tools/**` and per-domain `tools/**`: helper modules.
 - `src/weaviate/**`: local Weaviate utility scripts.
@@ -49,8 +51,11 @@ the referenced files still exist.
 - Output artifacts feed downstream knowledge-base and search/index services.
 - The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
   writes processed `jsonl`/`pkl`/`manifest.json` artifacts under the configured
-  NAS processed root, records parse local-ready through KB RPCs, and marks
+  NAS processed root using a `_pickle` suffixed path derived from the collection
+  storage path, records parse local-ready through KB RPCs, and marks
   `processed_s3_ready` through worker-lock-checked KB RPCs after S3 ready
-  checks.
+  checks. PM2 keeps the long-running worker process resident; the worker's
+  heartbeat loop keeps the job lock and PGMQ visibility timeout fresh while a
+  document is being parsed.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -38,9 +38,10 @@ flows.
 
 ## Processing Surface
 
-Scripts under `src/**`, dependency facts in `requirements.txt`, and local stack
-files under `docker/**` define processing behavior. Changes to input formats,
-output locations, chunking logic, embedding/index targets, OCR dependencies, or
+Scripts under `src/**`, dependency facts in `requirements.txt`, PM2 ecosystem
+files, and local stack files under `docker/**` define processing behavior and
+runtime operation. Changes to input formats, output locations, chunking logic,
+embedding/index targets, OCR dependencies, process-manager definitions, or
 long-running job commands require review of:
 
 - `README.md`

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -59,6 +59,21 @@ Run continuously:
 python -m src.kb_parse_worker.cli run
 ```
 
+Run continuously under PM2:
+
+```bash
+pm2 start ecosystem.kb_parse_worker.json
+pm2 save
+pm2 resurrect
+pm2 logs kb-parse-worker
+pm2 restart kb-parse-worker
+pm2 stop kb-parse-worker
+pm2 delete kb-parse-worker
+```
+
+The KB parse worker explicitly loads the repository-local `.env` file before
+falling back to the default `.env` lookup, so it can be started from either the
+repository root or the workspace root.
 Required runtime variables:
 
 ```text
@@ -86,6 +101,18 @@ keeps both overridable through runtime configuration:
 KB_PROCESSED_S3_BUCKET=tiangong
 KB_PROCESSED_S3_PREFIX=processed_docs
 ```
+
+Long-running parse jobs keep both the KB job lock and PGMQ visibility timeout
+fresh through `heartbeat_job(...)`. The worker defaults to:
+
+```text
+KB_PARSE_HEARTBEAT_INTERVAL_SECONDS=60
+```
+
+Processed artifact paths are derived from the collection storage path by adding
+`_pickle` to each path segment. For example, collection path
+`/course/thu_humanities` resolves raw files under `course/thu_humanities` and
+processed artifacts under `course_pickle/thu_humanities_pickle`.
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3
 sync is intentionally unavailable.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
 ---
 
 # Unstructure Documentation Standards

--- a/ecosystem.kb_parse_worker.json
+++ b/ecosystem.kb_parse_worker.json
@@ -1,0 +1,21 @@
+{
+  "apps": [
+    {
+      "name": "kb-parse-worker",
+      "cwd": ".",
+      "script": ".venv/bin/python",
+      "interpreter": "none",
+      "args": "-m src.kb_parse_worker.cli run --log-level INFO",
+      "watch": false,
+      "autorestart": true,
+      "max_restarts": 10,
+      "env": {
+        "PYTHONUNBUFFERED": "1"
+      },
+      "out_file": "logs/kb-parse-worker.out.log",
+      "error_file": "logs/kb-parse-worker.err.log",
+      "merge_logs": true,
+      "time": true
+    }
+  ]
+}

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -12,7 +12,7 @@ checkPaths:
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
 lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -36,7 +36,7 @@ def write_processed_artifacts(
         raise ValueError("EMPTY_RESULT")
 
     artifact_uuid = str(uuid.uuid4())
-    collection_root = nas_processed_root / snapshot.collection_storage_path
+    collection_root = nas_processed_root / snapshot.processed_storage_path
     tmp_dir = collection_root / ".tmp" / f"{snapshot.job_id}-{artifact_uuid}"
     final_dir = collection_root / snapshot.document_id
     if tmp_dir.exists():

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -49,6 +49,13 @@ def database_url_from_env() -> str:
     )
 
 
+def load_worker_env() -> None:
+    repo_env = Path(__file__).resolve().parents[2] / ".env"
+    if repo_env.exists():
+        load_dotenv(repo_env)
+    load_dotenv()
+
+
 @dataclass(frozen=True)
 class WorkerConfig:
     database_url: str
@@ -56,6 +63,7 @@ class WorkerConfig:
     queue_name: str
     queue_vt_seconds: int
     lock_seconds: int
+    heartbeat_interval_seconds: int
     poll_interval_seconds: int
     nas_raw_root: Path
     nas_processed_root: Path
@@ -70,7 +78,7 @@ class WorkerConfig:
 
     @classmethod
     def from_env(cls) -> "WorkerConfig":
-        load_dotenv()
+        load_worker_env()
         worker_id = os.getenv("KB_PARSE_WORKER_ID") or f"{socket.gethostname()}-{os.getpid()}"
         unstructure_url = os.getenv("UNSTRUCTURE_SERVE_URL")
         token = os.getenv("UNSTRUCTURE_SERVE_BEARER_TOKEN")
@@ -91,6 +99,7 @@ class WorkerConfig:
             queue_name=os.getenv("KB_PARSE_QUEUE", "kb_parse_queue"),
             queue_vt_seconds=_int_env("KB_PARSE_QUEUE_VT_SECONDS", 1800),
             lock_seconds=_int_env("KB_PARSE_LOCK_SECONDS", 1800),
+            heartbeat_interval_seconds=_int_env("KB_PARSE_HEARTBEAT_INTERVAL_SECONDS", 60),
             poll_interval_seconds=_int_env("KB_PARSE_POLL_INTERVAL_SECONDS", 5),
             nas_raw_root=Path(nas_raw_root),
             nas_processed_root=Path(nas_processed_root),

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -52,6 +52,7 @@ def build_manifest(
         "collection_id": snapshot.primary_collection_id,
         "collection_path": snapshot.collection_path,
         "collection_storage_path": snapshot.collection_storage_path,
+        "processed_storage_path": snapshot.processed_storage_path,
         "chunk_count": chunk_count,
         "artifacts": {
             "chunks_jsonl": jsonl_name,
@@ -79,4 +80,3 @@ def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
         json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
     )
-

--- a/src/kb_parse_worker/s3_ready.py
+++ b/src/kb_parse_worker/s3_ready.py
@@ -20,7 +20,7 @@ class S3ReadyResult:
 
 def processed_manifest_key(prefix: str, snapshot: ParseSnapshot) -> str:
     clean_prefix = prefix.strip("/")
-    return f"{clean_prefix}/{snapshot.collection_storage_path}/{snapshot.document_id}/manifest.json"
+    return f"{clean_prefix}/{snapshot.processed_storage_path}/{snapshot.document_id}/manifest.json"
 
 
 def wait_for_s3_processed_ready(
@@ -42,6 +42,8 @@ def wait_for_s3_processed_ready(
             raise RuntimeError(f"S3_MANIFEST_MISMATCH: {field}")
     if manifest.get("collection_storage_path") != expected.get("collection_storage_path"):
         raise RuntimeError("S3_MANIFEST_MISMATCH: collection_storage_path")
+    if manifest.get("processed_storage_path") != expected.get("processed_storage_path"):
+        raise RuntimeError("S3_MANIFEST_MISMATCH: processed_storage_path")
 
     base = "/".join(manifest_key.split("/")[:-1])
     for artifact_key, artifact_name in manifest["artifacts"].items():
@@ -59,4 +61,3 @@ def wait_for_s3_processed_ready(
                 raise RuntimeError(f"S3_ARTIFACT_MISMATCH: {artifact_name} sha256")
 
     return S3ReadyResult(ready=True, manifest_s3_key=manifest_key)
-

--- a/src/kb_parse_worker/snapshot.py
+++ b/src/kb_parse_worker/snapshot.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-import psycopg2.extras
-
 
 @dataclass(frozen=True)
 class ParseSnapshot:
@@ -25,6 +23,7 @@ class ParseSnapshot:
     collection_name: str
     collection_path: str
     collection_storage_path: str
+    processed_storage_path: str
     content_type: str | None
     collection_metadata_schema_json: dict
     document_metadata_json: dict
@@ -41,7 +40,16 @@ def collection_storage_path(collection_path: str) -> str:
     return "/".join(parts)
 
 
+def processed_storage_path(collection_storage_path: str) -> str:
+    parts = [part for part in collection_storage_path.split("/") if part]
+    if not parts:
+        raise ValueError("collection storage path cannot resolve to an empty processed path")
+    return "/".join(part if part.endswith("_pickle") else f"{part}_pickle" for part in parts)
+
+
 def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
+    import psycopg2.extras
+
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
@@ -80,6 +88,7 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
         raise RuntimeError(f"Document {row['document_id']} has no raw_uri.")
 
     path = str(row["collection_path"])
+    storage_path = collection_storage_path(path)
     return ParseSnapshot(
         job_id=str(row["job_id"]),
         document_id=str(row["document_id"]),
@@ -93,7 +102,8 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
         primary_collection_id=str(row["primary_collection_id"]),
         collection_name=str(row["collection_name"]),
         collection_path=path,
-        collection_storage_path=collection_storage_path(path),
+        collection_storage_path=storage_path,
+        processed_storage_path=processed_storage_path(storage_path),
         content_type=row["content_type"],
         collection_metadata_schema_json=dict(row["collection_metadata_schema_json"] or {}),
         document_metadata_json=dict(row["document_metadata_json"] or {}),
@@ -115,4 +125,3 @@ def resolve_raw_path(raw_uri: str, nas_raw_root: Path) -> Path:
             rel = rel[len("raw/") :]
         return nas_raw_root / rel
     raise ValueError(f"Unsupported raw_uri scheme: {parsed.scheme}")
-

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -32,6 +33,53 @@ def _validate_raw_file(path: Path, expected_size: int | None, expected_sha256: s
         raise RuntimeError("RAW_SIZE_MISMATCH")
     if _sha256(path).lower() != expected_sha256.lower():
         raise RuntimeError("RAW_HASH_MISMATCH")
+
+
+class LeaseMaintainer:
+    def __init__(self, config: WorkerConfig, job_id: str):
+        self.config = config
+        self.job_id = job_id
+        self._stop = threading.Event()
+        self._error: Exception | None = None
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"kb-parse-heartbeat-{job_id}",
+            daemon=True,
+        )
+
+    def __enter__(self) -> "LeaseMaintainer":
+        self.heartbeat()
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def heartbeat(self) -> None:
+        with control_plane.connect(self.config.database_url) as conn:
+            ok = control_plane.heartbeat_job(
+                conn,
+                self.job_id,
+                self.config.worker_id,
+                self.config.lock_seconds,
+                self.config.queue_vt_seconds,
+            )
+        if not ok:
+            raise RuntimeError("HEARTBEAT_LOST")
+
+    def check(self) -> None:
+        if self._error is not None:
+            raise RuntimeError("HEARTBEAT_LOST") from self._error
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.config.heartbeat_interval_seconds):
+            try:
+                self.heartbeat()
+            except Exception as exc:
+                LOGGER.exception("heartbeat failed for parse job %s", self.job_id)
+                self._error = exc
+                self._stop.set()
 
 
 class ParseWorker:
@@ -71,86 +119,84 @@ class ParseWorker:
             return
 
         try:
-            control_plane.heartbeat_job(
-                conn,
-                claimed.job_id,
-                self.config.worker_id,
-                self.config.lock_seconds,
-                self.config.queue_vt_seconds,
-            )
-            snapshot = load_parse_snapshot(conn, claimed.job_id)
-            raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
-            _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
+            with LeaseMaintainer(self.config, claimed.job_id) as lease:
+                snapshot = load_parse_snapshot(conn, claimed.job_id)
+                raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
+                _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
+                lease.check()
 
-            result = parse_with_unstructure_serve(
-                raw_path,
-                self.config.unstructure_serve_url,
-                self.config.unstructure_serve_bearer_token,
-            )
-            final_dir, artifact_info = write_processed_artifacts(
-                result,
-                snapshot,
-                self.config.nas_processed_root,
-                self.config.parser_profile,
-                self.config.parser_version,
-            )
-            manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
-            metadata_json = {
-                "processed": {
-                    "parser_profile": self.config.parser_profile,
-                    "parser_version": self.config.parser_version,
-                    "chunk_count": artifact_info.chunk_count,
-                    "artifact_uuid": artifact_info.artifact_uuid,
+                result = parse_with_unstructure_serve(
+                    raw_path,
+                    self.config.unstructure_serve_url,
+                    self.config.unstructure_serve_bearer_token,
+                )
+                lease.check()
+
+                final_dir, artifact_info = write_processed_artifacts(
+                    result,
+                    snapshot,
+                    self.config.nas_processed_root,
+                    self.config.parser_profile,
+                    self.config.parser_version,
+                )
+                lease.check()
+
+                manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
+                metadata_json = {
+                    "processed": {
+                        "parser_profile": self.config.parser_profile,
+                        "parser_version": self.config.parser_version,
+                        "chunk_count": artifact_info.chunk_count,
+                        "artifact_uuid": artifact_info.artifact_uuid,
+                    }
                 }
-            }
 
-            ok = control_plane.mark_parse_local_ready(
-                conn,
-                claimed.job_id,
-                self.config.worker_id,
-                claimed.document_id,
-                claimed.document_version,
-                manifest_local_uri,
-                artifact_info.artifact_uuid,
-                artifact_info.manifest_hash,
-                artifact_info.chunk_count,
-                metadata_json,
-            )
-            if not ok:
-                raise RuntimeError("mark_parse_local_ready returned false")
+                ok = control_plane.mark_parse_local_ready(
+                    conn,
+                    claimed.job_id,
+                    self.config.worker_id,
+                    claimed.document_id,
+                    claimed.document_version,
+                    manifest_local_uri,
+                    artifact_info.artifact_uuid,
+                    artifact_info.manifest_hash,
+                    artifact_info.chunk_count,
+                    metadata_json,
+                )
+                if not ok:
+                    raise RuntimeError("mark_parse_local_ready returned false")
+                lease.check()
 
-            if self.config.s3_ready_mode == "skip":
-                if not self.config.s3_bucket:
+                if self.config.s3_ready_mode == "skip":
                     manifest_s3_key = processed_manifest_key(self.config.s3_processed_prefix, snapshot)
                 else:
-                    manifest_s3_key = processed_manifest_key(self.config.s3_processed_prefix, snapshot)
-            else:
-                if not self.config.s3_bucket:
-                    raise RuntimeError("S3_NOT_READY: KB_PROCESSED_S3_BUCKET is required")
-                ready = wait_for_s3_processed_ready(
-                    snapshot,
-                    artifact_info,
-                    self.config.s3_bucket,
-                    self.config.s3_processed_prefix,
-                    self.config.s3_strict_hash,
-                )
-                manifest_s3_key = ready.manifest_s3_key
+                    if not self.config.s3_bucket:
+                        raise RuntimeError("S3_NOT_READY: KB_PROCESSED_S3_BUCKET is required")
+                    ready = wait_for_s3_processed_ready(
+                        snapshot,
+                        artifact_info,
+                        self.config.s3_bucket,
+                        self.config.s3_processed_prefix,
+                        self.config.s3_strict_hash,
+                    )
+                    manifest_s3_key = ready.manifest_s3_key
+                lease.check()
 
-            ok = control_plane.mark_processed_s3_ready(
-                conn,
-                claimed.job_id,
-                self.config.worker_id,
-                claimed.document_id,
-                claimed.document_version,
-                manifest_s3_key,
-                artifact_info.manifest_hash,
-                artifact_info.artifact_uuid,
-                manifest_local_uri,
-                artifact_info.chunk_count,
-            )
-            if not ok:
-                raise RuntimeError("mark_processed_s3_ready returned false")
-            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+                ok = control_plane.mark_processed_s3_ready(
+                    conn,
+                    claimed.job_id,
+                    self.config.worker_id,
+                    claimed.document_id,
+                    claimed.document_version,
+                    manifest_s3_key,
+                    artifact_info.manifest_hash,
+                    artifact_info.artifact_uuid,
+                    manifest_local_uri,
+                    artifact_info.chunk_count,
+                )
+                if not ok:
+                    raise RuntimeError("mark_processed_s3_ready returned false")
+                queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
         except Exception as exc:
             LOGGER.exception("parse job %s failed", claimed.job_id)
             retryable = str(exc) not in {"RAW_HASH_MISMATCH", "EMPTY_RESULT"}


### PR DESCRIPTION
## Summary
- derive processed pickle/json storage paths from `kb_collections.path`
- load worker runtime config from repo-local `.env`
- keep long-running parse jobs leased with a background heartbeat loop
- add PM2 `ecosystem.kb_parse_worker.json` for the F03 worker process

## Validation
- `python3 -m json.tool ecosystem.kb_parse_worker.json`
- `python3 -m compileall src/kb_parse_worker`
- `PYTHONPATH=. .venv/bin/python -m src.kb_parse_worker.cli --help`
- `docpact validate-config --root . --strict --format json`
- `docpact lint --root . --worktree --format json`
- `git diff --check`
- real S3 ready gate smoke against `s3://tiangong/processed_docs/...` with `strict_hash=True`

Refs tiangong-ai/workspace#5

## Review
@ li-nan@tsinghua.edu.cn