### PR TITLE
feat: add async S3-ready checker worker

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-05"
-lastReviewedCommit: "d9aa38132146c069372584dc658748e61bb6b551"
+lastReviewedAt: "2026-05-06"
+lastReviewedCommit: "17944cbd8614015728dc20b791a3e34821668234"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -27,11 +27,13 @@ Workflows are organized by source domain under `src/**`.
 
 - `src/{ali,education,edu_textbooks,esg,journals,patents,pptx,reports,standards}/**`:
   source-domain processing scripts.
-- `src/kb_parse_worker/**`: KB F03 parse worker that consumes
-  `kb_parse_queue`, claims jobs through the KB control plane, calls
-  Unstructure-Serve, and publishes processed artifacts.
-- `ecosystem.kb_parse_worker.json`: PM2 process definition for the KB parse
-  worker.
+- `src/kb_parse_worker/**`: KB F03 parse and S3-ready workers. The parse
+  worker consumes `kb_parse_queue`, claims jobs through the KB control plane,
+  calls Unstructure-Serve, publishes processed artifacts to NAS, and enqueues
+  the S3-ready check. The S3-ready worker consumes `kb_s3_ready_queue` and
+  marks processed artifacts ready after S3 verification.
+- `ecosystem.kb_parse_worker.json`: PM2 process definitions for the KB parse
+  worker and S3-ready worker.
 - `src/journals/**`: journal workflows; also read `src/journals/AGENTS.md`.
 - `src/tools/**` and per-domain `tools/**`: helper modules.
 - `src/weaviate/**`: local Weaviate utility scripts.
@@ -50,12 +52,16 @@ the referenced files still exist.
 
 - Output artifacts feed downstream knowledge-base and search/index services.
 - The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
-  writes processed `jsonl`/`pkl`/`manifest.json` artifacts under the configured
-  NAS processed root using a `_pickle` suffixed path derived from the collection
-  storage path, records parse local-ready through KB RPCs, and marks
-  `processed_s3_ready` through worker-lock-checked KB RPCs after S3 ready
-  checks. PM2 keeps the long-running worker process resident; the worker's
-  heartbeat loop keeps the job lock and PGMQ visibility timeout fresh while a
-  document is being parsed.
+  requires raw files to live under the collection-derived storage path using
+  the renamed canonical filename `{document_id}{file_ext}`, writes processed
+  `jsonl`/`pkl`/`manifest.json` artifacts under the configured NAS processed
+  root using a `_pickle` suffixed path derived from the collection storage
+  path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
+  That RPC completes the parse job, leaves the document in `s3_sync_pending`,
+  and enqueues a durable `s3_ready` job. A separate S3-ready worker then
+  verifies the processed manifest/jsonl/pkl objects after NAS-to-S3 sync and
+  calls `complete_s3_ready_check(...)` to mark `processed_s3_ready`. PM2 keeps
+  both long-running worker processes resident; each worker's heartbeat loop
+  keeps its active job lock and PGMQ visibility timeout fresh.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Unstructure Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: d9aa38132146c069372584dc658748e61bb6b551
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: f04e08fbe75d92c5ec518e8f043cdd2045c67bcd
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Unstructure Development Runbook

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -51,12 +51,14 @@ Run one queue message:
 
 ```bash
 python -m src.kb_parse_worker.cli once
+python -m src.kb_parse_worker.cli once --worker s3-ready
 ```
 
 Run continuously:
 
 ```bash
 python -m src.kb_parse_worker.cli run
+python -m src.kb_parse_worker.cli run --worker s3-ready
 ```
 
 Run continuously under PM2:
@@ -66,9 +68,13 @@ pm2 start ecosystem.kb_parse_worker.json
 pm2 save
 pm2 resurrect
 pm2 logs kb-parse-worker
+pm2 logs kb-s3-ready-worker
 pm2 restart kb-parse-worker
+pm2 restart kb-s3-ready-worker
 pm2 stop kb-parse-worker
+pm2 stop kb-s3-ready-worker
 pm2 delete kb-parse-worker
+pm2 delete kb-s3-ready-worker
 ```
 
 The KB parse worker explicitly loads the repository-local `.env` file before
@@ -85,6 +91,7 @@ NAS_PROCESSED_ROOT
 UNSTRUCTURE_SERVE_URL
 UNSTRUCTURE_SERVE_BEARER_TOKEN
 KB_PROCESSED_S3_BUCKET when overriding the default processed bucket
+KB_S3_READY_QUEUE when overriding the default s3-ready queue
 ```
 
 Current workspace worker deployment points `UNSTRUCTURE_SERVE_URL` at:
@@ -109,10 +116,27 @@ fresh through `heartbeat_job(...)`. The worker defaults to:
 KB_PARSE_HEARTBEAT_INTERVAL_SECONDS=60
 ```
 
-Processed artifact paths are derived from the collection storage path by adding
-`_pickle` to each path segment. For example, collection path
-`/course/thu_humanities` resolves raw files under `course/thu_humanities` and
-processed artifacts under `course_pickle/thu_humanities_pickle`.
+Raw and processed artifact paths are derived from the collection storage path.
+For example, collection path `/course/thu_humanities` resolves raw files under
+`course/thu_humanities/{document_id}{file_ext}` and processed artifacts under
+`course_pickle/thu_humanities_pickle/{document_id}`.
+
+The workers do not upload artifacts to S3 directly. The parse worker writes raw
+inputs and processed artifacts to NAS paths, calls
+`complete_parse_local_ready_and_enqueue_s3_check(...)`, archives the parse queue
+message, and exits without waiting for NAS-to-S3 sync. The S3-ready worker then
+waits for the NAS sync layer to publish processed artifacts to S3 before calling
+`complete_s3_ready_check(...)`. Tune the S3-ready worker check wait window with:
+
+```text
+KB_PARSE_S3_READY_TIMEOUT_SECONDS=900
+KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS=15
+```
+
+For deployments where NAS-to-S3 sync can take a long time, keep the parse worker
+and S3-ready worker as separate PM2 processes. Retry attempts for the S3-ready
+stage reuse `processed_manifest_local_uri` and only re-check processed S3
+readiness; they do not parse the document again.
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3
 sync is intentionally unavailable.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Unstructure Documentation Standards

--- a/ecosystem.kb_parse_worker.json
+++ b/ecosystem.kb_parse_worker.json
@@ -16,6 +16,23 @@
       "error_file": "logs/kb-parse-worker.err.log",
       "merge_logs": true,
       "time": true
+    },
+    {
+      "name": "kb-s3-ready-worker",
+      "cwd": ".",
+      "script": ".venv/bin/python",
+      "interpreter": "none",
+      "args": "-m src.kb_parse_worker.cli run --worker s3-ready --log-level INFO",
+      "watch": false,
+      "autorestart": true,
+      "max_restarts": 10,
+      "env": {
+        "PYTHONUNBUFFERED": "1"
+      },
+      "out_file": "logs/kb-s3-ready-worker.out.log",
+      "error_file": "logs/kb-s3-ready-worker.err.log",
+      "merge_logs": true,
+      "time": true
     }
   ]
 }

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-05
-lastReviewedCommit: bc3844c6ebb919932f8285957aa447b903faca0a
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/cli.py
+++ b/src/kb_parse_worker/cli.py
@@ -6,12 +6,18 @@ import argparse
 import logging
 
 from .config import WorkerConfig
-from .worker import ParseWorker
+from .worker import ParseWorker, S3ReadyWorker
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run the KB parse worker.")
+    parser = argparse.ArgumentParser(description="Run KB parse or S3-ready workers.")
     parser.add_argument("mode", choices=("once", "run"), help="Run one queue message or poll forever.")
+    parser.add_argument(
+        "--worker",
+        choices=("parse", "s3-ready"),
+        default="parse",
+        help="Worker role to run.",
+    )
     parser.add_argument("--log-level", default="INFO", help="Python logging level.")
     args = parser.parse_args()
 
@@ -19,7 +25,8 @@ def main() -> int:
         level=getattr(logging, args.log_level.upper()),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    worker = ParseWorker(WorkerConfig.from_env())
+    config = WorkerConfig.from_env()
+    worker = ParseWorker(config) if args.worker == "parse" else S3ReadyWorker(config)
     if args.mode == "once":
         worker.run_once()
     else:

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -61,6 +61,7 @@ class WorkerConfig:
     database_url: str
     worker_id: str
     queue_name: str
+    s3_ready_queue_name: str
     queue_vt_seconds: int
     lock_seconds: int
     heartbeat_interval_seconds: int
@@ -75,6 +76,8 @@ class WorkerConfig:
     s3_bucket: str | None
     s3_processed_prefix: str
     s3_strict_hash: bool
+    s3_ready_timeout_seconds: int
+    s3_ready_poll_interval_seconds: int
 
     @classmethod
     def from_env(cls) -> "WorkerConfig":
@@ -97,6 +100,7 @@ class WorkerConfig:
             database_url=database_url_from_env(),
             worker_id=worker_id,
             queue_name=os.getenv("KB_PARSE_QUEUE", "kb_parse_queue"),
+            s3_ready_queue_name=os.getenv("KB_S3_READY_QUEUE", "kb_s3_ready_queue"),
             queue_vt_seconds=_int_env("KB_PARSE_QUEUE_VT_SECONDS", 1800),
             lock_seconds=_int_env("KB_PARSE_LOCK_SECONDS", 1800),
             heartbeat_interval_seconds=_int_env("KB_PARSE_HEARTBEAT_INTERVAL_SECONDS", 60),
@@ -111,4 +115,6 @@ class WorkerConfig:
             s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET", "tiangong"),
             s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed_docs"),
             s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
+            s3_ready_timeout_seconds=_int_env("KB_PARSE_S3_READY_TIMEOUT_SECONDS", 900),
+            s3_ready_poll_interval_seconds=_int_env("KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS", 15),
         )

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -18,6 +18,15 @@ class ClaimedJob:
     payload_json: dict
 
 
+@dataclass(frozen=True)
+class S3ReadyEnqueueResult:
+    parse_job_id: str
+    parse_job_status: str
+    s3_ready_job_id: str
+    s3_ready_msg_id: int
+    document_status: str
+
+
 def connect(database_url: str):
     return psycopg2.connect(database_url)
 
@@ -137,6 +146,89 @@ def mark_processed_s3_ready(
         cur.execute(
             """
             select public.mark_processed_s3_ready(
+              %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                worker_id,
+                document_id,
+                document_version,
+                manifest_s3_key,
+                manifest_hash,
+                artifact_uuid,
+                manifest_local_uri,
+                chunk_count,
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
+
+
+def complete_parse_local_ready_and_enqueue_s3_check(
+    conn,
+    job_id: str,
+    worker_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_local_uri: str,
+    artifact_uuid: str,
+    manifest_hash: str,
+    chunk_count: int,
+    metadata_json: dict,
+    s3_ready_payload_json: dict,
+) -> S3ReadyEnqueueResult | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select *
+            from public.complete_parse_local_ready_and_enqueue_s3_check(
+              %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                worker_id,
+                document_id,
+                document_version,
+                manifest_local_uri,
+                artifact_uuid,
+                manifest_hash,
+                chunk_count,
+                psycopg2.extras.Json(metadata_json),
+                psycopg2.extras.Json(s3_ready_payload_json),
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    return S3ReadyEnqueueResult(
+        parse_job_id=str(row["parse_job_id"]),
+        parse_job_status=str(row["parse_job_status"]),
+        s3_ready_job_id=str(row["s3_ready_job_id"]),
+        s3_ready_msg_id=int(row["s3_ready_msg_id"]),
+        document_status=str(row["document_status"]),
+    )
+
+
+def complete_s3_ready_check(
+    conn,
+    job_id: str,
+    worker_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_s3_key: str,
+    manifest_hash: str,
+    artifact_uuid: str,
+    manifest_local_uri: str,
+    chunk_count: int,
+) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            select public.complete_s3_ready_check(
               %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -80,3 +80,19 @@ def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
         json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
     )
+
+
+def load_artifact_info(manifest_path: Path, manifest_hash: str | None = None) -> ArtifactInfo:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return ArtifactInfo(
+        artifact_uuid=str(manifest["artifact_uuid"]),
+        chunk_count=int(manifest["chunk_count"]),
+        jsonl_name=str(manifest["artifacts"]["chunks_jsonl"]),
+        pkl_name=str(manifest["artifacts"]["chunks_pkl"]),
+        jsonl_sha256=str(manifest["sha256"]["chunks_jsonl"]),
+        pkl_sha256=str(manifest["sha256"]["chunks_pkl"]),
+        jsonl_size_bytes=int(manifest["size_bytes"]["chunks_jsonl"]),
+        pkl_size_bytes=int(manifest["size_bytes"]["chunks_pkl"]),
+        manifest_hash=manifest_hash or file_sha256(manifest_path),
+        manifest=manifest,
+    )

--- a/src/kb_parse_worker/s3_ready.py
+++ b/src/kb_parse_worker/s3_ready.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from dataclasses import dataclass
 
 import boto3
+from botocore.exceptions import ClientError
 
 from .manifest import ArtifactInfo
 from .snapshot import ParseSnapshot
@@ -23,7 +25,7 @@ def processed_manifest_key(prefix: str, snapshot: ParseSnapshot) -> str:
     return f"{clean_prefix}/{snapshot.processed_storage_path}/{snapshot.document_id}/manifest.json"
 
 
-def wait_for_s3_processed_ready(
+def _check_s3_processed_ready(
     snapshot: ParseSnapshot,
     artifact_info: ArtifactInfo,
     bucket: str,
@@ -61,3 +63,30 @@ def wait_for_s3_processed_ready(
                 raise RuntimeError(f"S3_ARTIFACT_MISMATCH: {artifact_name} sha256")
 
     return S3ReadyResult(ready=True, manifest_s3_key=manifest_key)
+
+
+def wait_for_s3_processed_ready(
+    snapshot: ParseSnapshot,
+    artifact_info: ArtifactInfo,
+    bucket: str,
+    prefix: str,
+    strict_hash: bool = False,
+    timeout_seconds: int = 900,
+    poll_interval_seconds: int = 15,
+) -> S3ReadyResult:
+    deadline = time.monotonic() + max(0, timeout_seconds)
+    interval = max(1, poll_interval_seconds)
+
+    while True:
+        try:
+            return _check_s3_processed_ready(
+                snapshot,
+                artifact_info,
+                bucket,
+                prefix,
+                strict_hash,
+            )
+        except (ClientError, RuntimeError) as exc:
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"S3_NOT_READY_AFTER_TIMEOUT: {exc}") from exc
+            time.sleep(min(interval, max(0.0, deadline - time.monotonic())))

--- a/src/kb_parse_worker/snapshot.py
+++ b/src/kb_parse_worker/snapshot.py
@@ -13,6 +13,7 @@ class ParseSnapshot:
     job_id: str
     document_id: str
     document_version: int
+    document_status: str
     raw_uri: str
     raw_storage_region: str | None
     file_ext: str | None
@@ -28,6 +29,21 @@ class ParseSnapshot:
     collection_metadata_schema_json: dict
     document_metadata_json: dict
     job_payload_json: dict
+    processed_manifest_local_uri: str | None
+    processed_manifest_hash: str | None
+    processed_artifact_uuid: str | None
+    chunk_count: int | None
+
+
+def _safe_file_ext(file_ext: str | None, original_filename: str) -> str:
+    ext = file_ext or Path(original_filename).suffix
+    if not ext:
+        raise ValueError("document file extension is required for raw storage path")
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    if "/" in ext or "\\" in ext or ext in {".", ".."}:
+        raise ValueError(f"unsafe document file extension: {ext}")
+    return ext
 
 
 def collection_storage_path(collection_path: str) -> str:
@@ -47,7 +63,12 @@ def processed_storage_path(collection_storage_path: str) -> str:
     return "/".join(part if part.endswith("_pickle") else f"{part}_pickle" for part in parts)
 
 
-def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
+def raw_storage_path(snapshot: ParseSnapshot) -> str:
+    ext = _safe_file_ext(snapshot.file_ext, snapshot.original_filename)
+    return f"{snapshot.collection_storage_path}/{snapshot.document_id}{ext}"
+
+
+def load_job_snapshot(conn, job_id: str, expected_stage: str) -> ParseSnapshot:
     import psycopg2.extras
 
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
@@ -57,6 +78,7 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
               j.id as job_id,
               j.payload_json as job_payload_json,
               d.id as document_id,
+              d.status as document_status,
               d.document_version,
               d.raw_uri,
               d.raw_storage_region,
@@ -66,6 +88,10 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
               d.original_filename,
               d.primary_collection_id,
               d.metadata_json as document_metadata_json,
+              d.processed_manifest_local_uri,
+              d.processed_manifest_hash,
+              d.processed_artifact_uuid,
+              d.chunk_count,
               c.name as collection_name,
               c.path as collection_path,
               c.content_type,
@@ -74,16 +100,16 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
             join public.kb_documents d on d.id = j.document_id
             join public.kb_collections c on c.id = d.primary_collection_id
             where j.id = %s
-              and j.stage = 'parse'
+              and j.stage = %s::public.kb_job_stage
               and j.status = 'running'
               and d.deleted_at is null
               and j.document_version = d.document_version
             """,
-            (job_id,),
+            (job_id, expected_stage),
         )
         row = cur.fetchone()
     if row is None:
-        raise RuntimeError(f"No runnable parse snapshot for job {job_id}.")
+        raise RuntimeError(f"No runnable {expected_stage} snapshot for job {job_id}.")
     if not row["raw_uri"]:
         raise RuntimeError(f"Document {row['document_id']} has no raw_uri.")
 
@@ -93,6 +119,7 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
         job_id=str(row["job_id"]),
         document_id=str(row["document_id"]),
         document_version=int(row["document_version"]),
+        document_status=str(row["document_status"]),
         raw_uri=str(row["raw_uri"]),
         raw_storage_region=row["raw_storage_region"],
         file_ext=row["file_ext"],
@@ -108,7 +135,21 @@ def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
         collection_metadata_schema_json=dict(row["collection_metadata_schema_json"] or {}),
         document_metadata_json=dict(row["document_metadata_json"] or {}),
         job_payload_json=dict(row["job_payload_json"] or {}),
+        processed_manifest_local_uri=row["processed_manifest_local_uri"],
+        processed_manifest_hash=row["processed_manifest_hash"],
+        processed_artifact_uuid=str(row["processed_artifact_uuid"])
+        if row["processed_artifact_uuid"]
+        else None,
+        chunk_count=row["chunk_count"],
     )
+
+
+def load_parse_snapshot(conn, job_id: str) -> ParseSnapshot:
+    return load_job_snapshot(conn, job_id, "parse")
+
+
+def load_s3_ready_snapshot(conn, job_id: str) -> ParseSnapshot:
+    return load_job_snapshot(conn, job_id, "s3_ready")
 
 
 def resolve_raw_path(raw_uri: str, nas_raw_root: Path) -> Path:
@@ -125,3 +166,12 @@ def resolve_raw_path(raw_uri: str, nas_raw_root: Path) -> Path:
             rel = rel[len("raw/") :]
         return nas_raw_root / rel
     raise ValueError(f"Unsupported raw_uri scheme: {parsed.scheme}")
+
+
+def validate_raw_storage_path(snapshot: ParseSnapshot, raw_path: Path, nas_raw_root: Path) -> None:
+    expected = nas_raw_root / raw_storage_path(snapshot)
+    if raw_path.resolve() != expected.resolve():
+        raise RuntimeError(
+            "RAW_STORAGE_PATH_MISMATCH: "
+            f"expected {expected.as_posix()} from collection path {snapshot.collection_path}"
+        )

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -1,4 +1,4 @@
-"""KB parse worker orchestration."""
+"""KB parse and S3-ready worker orchestration."""
 
 from __future__ import annotations
 
@@ -11,9 +11,15 @@ from pathlib import Path
 from . import control_plane, queue
 from .artifacts import write_processed_artifacts
 from .config import WorkerConfig
+from .manifest import load_artifact_info
 from .parser_adapter import parse_with_unstructure_serve
 from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
-from .snapshot import load_parse_snapshot, resolve_raw_path
+from .snapshot import (
+    load_parse_snapshot,
+    load_s3_ready_snapshot,
+    resolve_raw_path,
+    validate_raw_storage_path,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -121,37 +127,68 @@ class ParseWorker:
         try:
             with LeaseMaintainer(self.config, claimed.job_id) as lease:
                 snapshot = load_parse_snapshot(conn, claimed.job_id)
-                raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
-                _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
-                lease.check()
-
-                result = parse_with_unstructure_serve(
-                    raw_path,
-                    self.config.unstructure_serve_url,
-                    self.config.unstructure_serve_bearer_token,
-                )
-                lease.check()
-
-                final_dir, artifact_info = write_processed_artifacts(
-                    result,
-                    snapshot,
-                    self.config.nas_processed_root,
-                    self.config.parser_profile,
-                    self.config.parser_version,
-                )
-                lease.check()
-
-                manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
-                metadata_json = {
-                    "processed": {
-                        "parser_profile": self.config.parser_profile,
-                        "parser_version": self.config.parser_version,
-                        "chunk_count": artifact_info.chunk_count,
-                        "artifact_uuid": artifact_info.artifact_uuid,
+                if snapshot.processed_manifest_local_uri and snapshot.processed_artifact_uuid:
+                    manifest_path = Path(snapshot.processed_manifest_local_uri)
+                    artifact_info = load_artifact_info(manifest_path, snapshot.processed_manifest_hash)
+                    manifest_local_uri = manifest_path.as_posix()
+                    metadata_json = {
+                        "processed": {
+                            "parser_profile": artifact_info.manifest.get(
+                                "parser_profile",
+                                self.config.parser_profile,
+                            ),
+                            "parser_version": artifact_info.manifest.get(
+                                "parser_version",
+                                self.config.parser_version,
+                            ),
+                            "chunk_count": artifact_info.chunk_count,
+                            "artifact_uuid": artifact_info.artifact_uuid,
+                        }
                     }
-                }
+                else:
+                    raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
+                    validate_raw_storage_path(snapshot, raw_path, self.config.nas_raw_root)
+                    _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
+                    lease.check()
 
-                ok = control_plane.mark_parse_local_ready(
+                    result = parse_with_unstructure_serve(
+                        raw_path,
+                        self.config.unstructure_serve_url,
+                        self.config.unstructure_serve_bearer_token,
+                    )
+                    lease.check()
+
+                    final_dir, artifact_info = write_processed_artifacts(
+                        result,
+                        snapshot,
+                        self.config.nas_processed_root,
+                        self.config.parser_profile,
+                        self.config.parser_version,
+                    )
+                    lease.check()
+
+                    manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
+                    metadata_json = {
+                        "processed": {
+                            "parser_profile": self.config.parser_profile,
+                            "parser_version": self.config.parser_version,
+                            "chunk_count": artifact_info.chunk_count,
+                            "artifact_uuid": artifact_info.artifact_uuid,
+                        }
+                    }
+
+                s3_ready_payload_json = {
+                    "collection_path": snapshot.collection_path,
+                    "collection_storage_path": snapshot.collection_storage_path,
+                    "processed_storage_path": snapshot.processed_storage_path,
+                    "manifest_s3_key": processed_manifest_key(
+                        self.config.s3_processed_prefix,
+                        snapshot,
+                    ),
+                    "s3_bucket": self.config.s3_bucket,
+                    "s3_prefix": self.config.s3_processed_prefix,
+                }
+                s3_ready_result = control_plane.complete_parse_local_ready_and_enqueue_s3_check(
                     conn,
                     claimed.job_id,
                     self.config.worker_id,
@@ -162,9 +199,80 @@ class ParseWorker:
                     artifact_info.manifest_hash,
                     artifact_info.chunk_count,
                     metadata_json,
+                    s3_ready_payload_json,
                 )
-                if not ok:
-                    raise RuntimeError("mark_parse_local_ready returned false")
+                if s3_ready_result is None:
+                    raise RuntimeError("complete_parse_local_ready_and_enqueue_s3_check returned no row")
+                LOGGER.info(
+                    "parse job %s completed local artifacts and queued s3_ready job %s msg %s",
+                    claimed.job_id,
+                    s3_ready_result.s3_ready_job_id,
+                    s3_ready_result.s3_ready_msg_id,
+                )
+                queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+        except Exception as exc:
+            LOGGER.exception("parse job %s failed", claimed.job_id)
+            retryable = str(exc) not in {
+                "RAW_HASH_MISMATCH",
+                "EMPTY_RESULT",
+            } and not str(exc).startswith("RAW_STORAGE_PATH_MISMATCH")
+            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, retryable, str(exc))
+
+
+class S3ReadyWorker:
+    def __init__(self, config: WorkerConfig):
+        self.config = config
+
+    def run_forever(self) -> None:
+        while True:
+            processed = self.run_once()
+            if not processed:
+                time.sleep(self.config.poll_interval_seconds)
+
+    def run_once(self) -> bool:
+        with control_plane.connect(self.config.database_url) as conn:
+            message = queue.read_one(
+                conn,
+                self.config.s3_ready_queue_name,
+                self.config.queue_vt_seconds,
+            )
+            if message is None:
+                return False
+            self.process_message(conn, message)
+            return True
+
+    def process_message(self, conn, message: queue.QueueMessage) -> None:
+        claimed = control_plane.claim_job(
+            conn,
+            message.job_id,
+            self.config.s3_ready_queue_name,
+            message.msg_id,
+            self.config.worker_id,
+            self.config.lock_seconds,
+        )
+        if claimed is None:
+            LOGGER.info("s3_ready job %s was not claimable", message.job_id)
+            queue.archive_job_message(conn, message.job_id, self.config.worker_id)
+            return
+        if claimed.stage != "s3_ready":
+            control_plane.fail_job(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                False,
+                "UNSUPPORTED_STAGE",
+                "s3_ready",
+            )
+            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+            return
+
+        try:
+            with LeaseMaintainer(self.config, claimed.job_id) as lease:
+                snapshot = load_s3_ready_snapshot(conn, claimed.job_id)
+                if not snapshot.processed_manifest_local_uri:
+                    raise RuntimeError("LOCAL_MANIFEST_MISSING")
+                manifest_path = Path(snapshot.processed_manifest_local_uri)
+                artifact_info = load_artifact_info(manifest_path, snapshot.processed_manifest_hash)
                 lease.check()
 
                 if self.config.s3_ready_mode == "skip":
@@ -178,11 +286,13 @@ class ParseWorker:
                         self.config.s3_bucket,
                         self.config.s3_processed_prefix,
                         self.config.s3_strict_hash,
+                        self.config.s3_ready_timeout_seconds,
+                        self.config.s3_ready_poll_interval_seconds,
                     )
                     manifest_s3_key = ready.manifest_s3_key
                 lease.check()
 
-                ok = control_plane.mark_processed_s3_ready(
+                ok = control_plane.complete_s3_ready_check(
                     conn,
                     claimed.job_id,
                     self.config.worker_id,
@@ -191,13 +301,19 @@ class ParseWorker:
                     manifest_s3_key,
                     artifact_info.manifest_hash,
                     artifact_info.artifact_uuid,
-                    manifest_local_uri,
+                    manifest_path.as_posix(),
                     artifact_info.chunk_count,
                 )
                 if not ok:
-                    raise RuntimeError("mark_processed_s3_ready returned false")
+                    raise RuntimeError("complete_s3_ready_check returned false")
                 queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
         except Exception as exc:
-            LOGGER.exception("parse job %s failed", claimed.job_id)
-            retryable = str(exc) not in {"RAW_HASH_MISMATCH", "EMPTY_RESULT"}
-            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, retryable, str(exc))
+            LOGGER.exception("s3_ready job %s failed", claimed.job_id)
+            control_plane.fail_job(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                True,
+                str(exc),
+                "s3_ready",
+            )


### PR DESCRIPTION
Related: tiangong-ai/workspace#21

## Summary

- Split the F03 flow into parse-local completion plus a durable async S3-ready checker.
- Change the parse worker to call `complete_parse_local_ready_and_enqueue_s3_check(...)`, archive the parse message, and stop waiting on NAS-to-S3 sync.
- Add `S3ReadyWorker` for `kb_s3_ready_queue`, with processed manifest/jsonl/pkl S3 checks before `complete_s3_ready_check(...)`.
- Add PM2 config for `kb-s3-ready-worker` and update Unstructure architecture/runbook docs.

## Validation

- `.venv/bin/python -m compileall src/kb_parse_worker`
- `python3 -m json.tool ecosystem.kb_parse_worker.json >/dev/null`
- `git diff --check`
- `docpact validate-config --root . --strict`
- Read-only DB contract check confirmed `s3_ready`, `kb_s3_ready_queue`, `complete_parse_local_ready_and_enqueue_s3_check(...)`, and `complete_s3_ready_check(...)` exist.
- Local fake S3 client smoke verified processed manifest/jsonl/pkl size and strict hash checks.

## Notes

- The checker does not enqueue index jobs; F05 remains responsible for `processed_s3_ready -> index_queued`.
- Raw S3 archive is not a default blocking gate for processed readiness.

cc li-nan@tsinghua.edu.cn
