### PR TITLE
feat: embed chunks in F03 parse artifacts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-06"
-lastReviewedCommit: "17944cbd8614015728dc20b791a3e34821668234"
+lastReviewedAt: "2026-05-07"
+lastReviewedCommit: "42c78a97059a9f68f953e5e27b7fff662f7e7185"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -57,6 +57,10 @@ the referenced files still exist.
   `jsonl`/`pkl`/`manifest.json` artifacts under the configured NAS processed
   root using a `_pickle` suffixed path derived from the collection storage
   path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
+  Before artifact writes, the worker embeds every chunk `text` field through the
+  OpenAI-compatible Qwen3-Embedding-8B endpoint, locally truncates and
+  normalizes vectors to 1536 dimensions, stores vectors in the pickle chunks
+  under `embedding`, and excludes `embedding` from the JSONL artifact.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
   and enqueues a durable `s3_ready` job. A separate S3-ready worker then
   verifies the processed manifest/jsonl/pkl objects after NAS-to-S3 sync and

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -80,6 +80,24 @@ pm2 delete kb-s3-ready-worker
 The KB parse worker explicitly loads the repository-local `.env` file before
 falling back to the default `.env` lookup, so it can be started from either the
 repository root or the workspace root.
+
+Current workspace live F03 workers run on the self-hosted parse worker host,
+not on the local operator machine. The worker host is the machine that can read
+`NAS_RAW_ROOT`, write `NAS_PROCESSED_ROOT`, reach Supabase Postgres, and call
+Unstructure-Serve. Operator-side variables such as `PARSE_WORKER_HOST`,
+`PARSE_WORKER_SSH_PORT`, `PARSE_WORKER_USER`, `PARSE_WORKER_SSH_HOST_ALIAS`,
+`SUPABASE_DB_*`, `NAS_*`, `UNSTRUCTURE_SERVE_*`, `KB_PROCESSED_S3_*`, and AWS
+credentials, plus `KB_EMBEDDING_*`, are loaded from the root workspace
+`.env.ops.local` only for manual operations, SSH login, and smoke-test
+preparation. Do not treat root
+`.env.ops.local` as worker runtime configuration and do not copy secret values
+into docs, issues, PRs, or chat.
+
+The remote worker runtime must receive the required values from the remote
+`TianGong-AI-Unstructure/.env` file or host process environment. Run live
+`once`, `run`, PM2 restart, and S3-ready checks on that remote host unless the
+local machine has an equivalent NAS mount and the same runtime variables.
+
 Required runtime variables:
 
 ```text
@@ -90,6 +108,8 @@ NAS_RAW_ROOT
 NAS_PROCESSED_ROOT
 UNSTRUCTURE_SERVE_URL
 UNSTRUCTURE_SERVE_BEARER_TOKEN
+KB_EMBEDDING_BASE_URL
+KB_EMBEDDING_MODEL
 KB_PROCESSED_S3_BUCKET when overriding the default processed bucket
 KB_S3_READY_QUEUE when overriding the default s3-ready queue
 ```
@@ -98,6 +118,22 @@ Current workspace worker deployment points `UNSTRUCTURE_SERVE_URL` at:
 
 ```text
 UNSTRUCTURE_SERVE_URL=http://192.168.1.140:7770/mineru_with_images
+```
+
+After MinerU returns chunks, the parse worker calls the OpenAI-compatible
+embedding endpoint before writing artifacts. The pickle artifact stores each
+chunk with an `embedding` key, while the JSONL artifact omits embeddings to keep
+line-oriented inspection light. The worker requests provider-default
+Qwen3-Embedding-8B vectors, then locally truncates and normalizes them to the
+configured dimension:
+
+```text
+KB_EMBEDDING_BASE_URL=http://192.168.1.140:7710/v1
+KB_EMBEDDING_MODEL=Qwen/Qwen3-Embedding-8B
+KB_EMBEDDING_API_KEY=EMPTY
+KB_EMBEDDING_DIMENSIONS=1536
+KB_EMBEDDING_BATCH_SIZE=32
+KB_EMBEDDING_TIMEOUT_SECONDS=600
 ```
 
 Current workspace design documents point the processed S3 location at bucket

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -31,6 +31,7 @@ def write_processed_artifacts(
     nas_processed_root: Path,
     parser_profile: str,
     parser_version: str,
+    embedding: dict[str, Any] | None = None,
 ) -> tuple[Path, ArtifactInfo]:
     if not result:
         raise ValueError("EMPTY_RESULT")
@@ -47,6 +48,8 @@ def write_processed_artifacts(
     pkl_path = tmp_dir / f"{artifact_uuid}.pkl"
     with jsonl_path.open("w", encoding="utf-8") as handle:
         for item in result:
+            if isinstance(item, dict) and "embedding" in item:
+                item = {key: value for key, value in item.items() if key != "embedding"}
             handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
     with pkl_path.open("wb") as handle:
         pickle.dump(result, handle)
@@ -66,6 +69,7 @@ def write_processed_artifacts(
         pkl_path=pkl_path,
         parser_profile=parser_profile,
         parser_version=parser_version,
+        embedding=embedding,
     )
     write_manifest(tmp_dir / "manifest.tmp.json", manifest)
     os.replace(tmp_dir / "manifest.tmp.json", tmp_dir / "manifest.json")

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -78,6 +78,12 @@ class WorkerConfig:
     s3_strict_hash: bool
     s3_ready_timeout_seconds: int
     s3_ready_poll_interval_seconds: int
+    embedding_base_url: str
+    embedding_model: str
+    embedding_api_key: str
+    embedding_dimensions: int
+    embedding_batch_size: int
+    embedding_timeout_seconds: int
 
     @classmethod
     def from_env(cls) -> "WorkerConfig":
@@ -117,4 +123,10 @@ class WorkerConfig:
             s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
             s3_ready_timeout_seconds=_int_env("KB_PARSE_S3_READY_TIMEOUT_SECONDS", 900),
             s3_ready_poll_interval_seconds=_int_env("KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS", 15),
+            embedding_base_url=os.getenv("KB_EMBEDDING_BASE_URL", "http://192.168.1.140:7710/v1"),
+            embedding_model=os.getenv("KB_EMBEDDING_MODEL", "Qwen/Qwen3-Embedding-8B"),
+            embedding_api_key=os.getenv("KB_EMBEDDING_API_KEY", "EMPTY"),
+            embedding_dimensions=_int_env("KB_EMBEDDING_DIMENSIONS", 1536),
+            embedding_batch_size=_int_env("KB_EMBEDDING_BATCH_SIZE", 32),
+            embedding_timeout_seconds=_int_env("KB_EMBEDDING_TIMEOUT_SECONDS", 600),
         )

--- a/src/kb_parse_worker/embedding_client.py
+++ b/src/kb_parse_worker/embedding_client.py
@@ -1,0 +1,120 @@
+"""Embedding client for KB parse chunks."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import requests
+
+
+class EmbeddingError(RuntimeError):
+    pass
+
+
+def _chunk_text(item: Any) -> str:
+    if not isinstance(item, dict):
+        raise EmbeddingError("EMBEDDING_CHUNK_NOT_OBJECT")
+    text = item.get("text", "")
+    if text is None:
+        return ""
+    if isinstance(text, str):
+        return text
+    return json.dumps(text, ensure_ascii=False, sort_keys=True)
+
+
+def _normalize_truncated(vector: list[Any], dimensions: int) -> list[float]:
+    if len(vector) < dimensions:
+        raise EmbeddingError(
+            f"EMBEDDING_DIMENSION_TOO_SMALL: got {len(vector)}, need {dimensions}"
+        )
+    truncated = [float(value) for value in vector[:dimensions]]
+    norm = math.sqrt(sum(value * value for value in truncated))
+    if norm == 0:
+        return truncated
+    return [value / norm for value in truncated]
+
+
+def _embedding_endpoint(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/embeddings"
+
+
+def _embed_text_batch(
+    texts: list[str],
+    base_url: str,
+    model: str,
+    api_key: str,
+    dimensions: int,
+    timeout_seconds: int,
+) -> list[list[float]]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        response = requests.post(
+            _embedding_endpoint(base_url),
+            headers=headers,
+            json={"model": model, "input": texts},
+            timeout=timeout_seconds,
+        )
+    except requests.RequestException as exc:
+        raise EmbeddingError(f"embedding request failed: {exc}") from exc
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise EmbeddingError(
+            f"embedding http error {response.status_code}: {response.text[:500]}"
+        ) from exc
+
+    payload = response.json()
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise EmbeddingError("embedding response missing data list")
+    if len(data) != len(texts):
+        raise EmbeddingError(
+            f"embedding response count mismatch: got {len(data)}, expected {len(texts)}"
+        )
+
+    ordered = sorted(data, key=lambda item: int(item.get("index", 0)))
+    vectors: list[list[float]] = []
+    for item in ordered:
+        embedding = item.get("embedding")
+        if not isinstance(embedding, list):
+            raise EmbeddingError("embedding response item missing embedding list")
+        vectors.append(_normalize_truncated(embedding, dimensions))
+    return vectors
+
+
+def add_chunk_embeddings(
+    chunks: list[Any],
+    base_url: str,
+    model: str,
+    api_key: str,
+    dimensions: int,
+    batch_size: int,
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    if dimensions <= 0:
+        raise ValueError("KB_EMBEDDING_DIMENSIONS must be positive")
+    if batch_size <= 0:
+        raise ValueError("KB_EMBEDDING_BATCH_SIZE must be positive")
+
+    texts = [_chunk_text(item) for item in chunks]
+    embedded_chunks: list[dict[str, Any]] = []
+    for offset in range(0, len(chunks), batch_size):
+        batch_chunks = chunks[offset : offset + batch_size]
+        batch_texts = texts[offset : offset + batch_size]
+        vectors = _embed_text_batch(
+            batch_texts,
+            base_url,
+            model,
+            api_key,
+            dimensions,
+            timeout_seconds,
+        )
+        for item, vector in zip(batch_chunks, vectors, strict=True):
+            chunk = dict(item)
+            chunk["embedding"] = vector
+            embedded_chunks.append(chunk)
+    return embedded_chunks

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -42,6 +42,7 @@ def build_manifest(
     pkl_path: Path,
     parser_profile: str,
     parser_version: str,
+    embedding: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], str]:
     jsonl_name = jsonl_path.name
     pkl_name = pkl_path.name
@@ -71,6 +72,8 @@ def build_manifest(
         "parser_profile": parser_profile,
         "parser_version": parser_version,
     }
+    if embedding is not None:
+        manifest["embedding"] = embedding
     manifest_bytes = json.dumps(manifest, ensure_ascii=False, sort_keys=True).encode("utf-8")
     return manifest, hashlib.sha256(manifest_bytes).hexdigest()
 

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from . import control_plane, queue
 from .artifacts import write_processed_artifacts
 from .config import WorkerConfig
+from .embedding_client import add_chunk_embeddings
 from .manifest import load_artifact_info
 from .parser_adapter import parse_with_unstructure_serve
 from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
@@ -158,12 +159,31 @@ class ParseWorker:
                     )
                     lease.check()
 
+                    result = add_chunk_embeddings(
+                        result,
+                        self.config.embedding_base_url,
+                        self.config.embedding_model,
+                        self.config.embedding_api_key,
+                        self.config.embedding_dimensions,
+                        self.config.embedding_batch_size,
+                        self.config.embedding_timeout_seconds,
+                    )
+                    lease.check()
+
+                    embedding_metadata = {
+                        "model": self.config.embedding_model,
+                        "base_url": self.config.embedding_base_url,
+                        "dimensions": self.config.embedding_dimensions,
+                        "normalized": True,
+                        "source_dimensions": "provider_default",
+                    }
                     final_dir, artifact_info = write_processed_artifacts(
                         result,
                         snapshot,
                         self.config.nas_processed_root,
                         self.config.parser_profile,
                         self.config.parser_version,
+                        embedding_metadata,
                     )
                     lease.check()
 
@@ -174,6 +194,7 @@ class ParseWorker:
                             "parser_version": self.config.parser_version,
                             "chunk_count": artifact_info.chunk_count,
                             "artifact_uuid": artifact_info.artifact_uuid,
+                            "embedding": embedding_metadata,
                         }
                     }
 


### PR DESCRIPTION
@li-nan@tsinghua.edu.cn

## Summary
- add an OpenAI-compatible embedding client for the F03 parse worker
- compute Qwen/Qwen3-Embedding-8B vectors after MinerU parsing and before pickle writes
- locally truncate and normalize vectors to 1536 dimensions
- keep `embedding` in pickle chunks, omit `embedding` from JSONL chunks, and record embedding metadata in manifests/job metadata
- document the new runtime variables and artifact behavior

## Validation
- `.venv/bin/python -m compileall src/kb_parse_worker`
- `docpact validate-config --root . --strict`
- local fake embedding/artifact smoke test: pickle has embedding, JSONL omits embedding
- self-hosted worker host real embedding smoke test against `http://192.168.1.140:7710/v1`: vector_dim=1536, norm=1.0
- self-hosted worker host F03 parse `once`: job `ba2973d0-66b0-4806-9ec3-fc294454162f` completed local artifacts, 145 chunks, pickle embedding dim 1536, JSONL has no embedding
