### PR TITLE
fix: filter empty KB chunks and persist full text artifact

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-07"
-lastReviewedCommit: "42c78a97059a9f68f953e5e27b7fff662f7e7185"
+lastReviewedAt: "2026-05-10"
+lastReviewedCommit: "163c1c726891c17cba2ef3442e96b92af593ef6b"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Unstructure Architecture
@@ -54,16 +54,19 @@ the referenced files still exist.
 - The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
   requires raw files to live under the collection-derived storage path using
   the renamed canonical filename `{document_id}{file_ext}`, writes processed
-  `jsonl`/`pkl`/`manifest.json` artifacts under the configured NAS processed
-  root using a `_pickle` suffixed path derived from the collection storage
-  path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
-  Before artifact writes, the worker embeds every chunk `text` field through the
-  OpenAI-compatible Qwen3-Embedding-8B endpoint, locally truncates and
-  normalizes vectors to 1536 dimensions, stores vectors in the pickle chunks
+  `jsonl`/`pkl`/`txt`/`manifest.json` artifacts under the configured NAS
+  processed root using a `_pickle` suffixed path derived from the collection
+  storage path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
+  The worker requests `return_txt=true` from Unstructure-Serve, drops parser
+  chunks whose `text` is empty before embedding, and writes the returned
+  whole-document text as `{artifact_uuid}.txt` beside the pickle artifact.
+  Before artifact writes, the worker embeds every remaining chunk `text` field
+  through the OpenAI-compatible Qwen3-Embedding-8B endpoint, locally truncates
+  and normalizes vectors to 1536 dimensions, stores vectors in the pickle chunks
   under `embedding`, and excludes `embedding` from the JSONL artifact.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
   and enqueues a durable `s3_ready` job. A separate S3-ready worker then
-  verifies the processed manifest/jsonl/pkl objects after NAS-to-S3 sync and
+  verifies the processed manifest/jsonl/pkl/txt objects after NAS-to-S3 sync and
   calls `complete_s3_ready_check(...)` to mark `processed_s3_ready`. PM2 keeps
   both long-running worker processes resident; each worker's heartbeat loop
   keeps its active job lock and PGMQ visibility timeout fresh.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 17944cbd8614015728dc20b791a3e34821668234
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Unstructure Development Runbook
@@ -120,12 +120,18 @@ Current workspace worker deployment points `UNSTRUCTURE_SERVE_URL` at:
 UNSTRUCTURE_SERVE_URL=http://192.168.1.140:7770/mineru_with_images
 ```
 
+The parse worker calls Unstructure-Serve with `return_txt=true`. It uses the
+returned `result` JSON for chunk embeddings and pickle generation, drops any
+returned chunk whose `text` is empty before embedding, and writes the returned
+whole-document `txt` payload as `{artifact_uuid}.txt` beside
+`{artifact_uuid}.pkl`.
+
 After MinerU returns chunks, the parse worker calls the OpenAI-compatible
 embedding endpoint before writing artifacts. The pickle artifact stores each
-chunk with an `embedding` key, while the JSONL artifact omits embeddings to keep
-line-oriented inspection light. The worker requests provider-default
-Qwen3-Embedding-8B vectors, then locally truncates and normalizes them to the
-configured dimension:
+remaining chunk with an `embedding` key, while the JSONL artifact omits
+embeddings to keep line-oriented inspection light. The worker requests
+provider-default Qwen3-Embedding-8B vectors, then locally truncates and
+normalizes them to the configured dimension:
 
 ```text
 KB_EMBEDDING_BASE_URL=http://192.168.1.140:7710/v1
@@ -158,7 +164,8 @@ For example, collection path `/course/thu_humanities` resolves raw files under
 `course_pickle/thu_humanities_pickle/{document_id}`.
 
 The workers do not upload artifacts to S3 directly. The parse worker writes raw
-inputs and processed artifacts to NAS paths, calls
+inputs and processed artifacts to NAS paths, including the manifest-declared
+JSONL, pickle, and optional full-text TXT artifacts, calls
 `complete_parse_local_ready_and_enqueue_s3_check(...)`, archives the parse queue
 message, and exits without waiting for NAS-to-S3 sync. The S3-ready worker then
 waits for the NAS sync layer to publish processed artifacts to S3 before calling

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-07
-lastReviewedCommit: 42c78a97059a9f68f953e5e27b7fff662f7e7185
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -32,6 +32,7 @@ def write_processed_artifacts(
     parser_profile: str,
     parser_version: str,
     embedding: dict[str, Any] | None = None,
+    full_text: str | None = None,
 ) -> tuple[Path, ArtifactInfo]:
     if not result:
         raise ValueError("EMPTY_RESULT")
@@ -46,6 +47,7 @@ def write_processed_artifacts(
 
     jsonl_path = tmp_dir / f"{artifact_uuid}.jsonl"
     pkl_path = tmp_dir / f"{artifact_uuid}.pkl"
+    txt_path = tmp_dir / f"{artifact_uuid}.txt" if full_text is not None else None
     with jsonl_path.open("w", encoding="utf-8") as handle:
         for item in result:
             if isinstance(item, dict) and "embedding" in item:
@@ -53,8 +55,12 @@ def write_processed_artifacts(
             handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
     with pkl_path.open("wb") as handle:
         pickle.dump(result, handle)
+    if txt_path is not None:
+        txt_path.write_text(full_text, encoding="utf-8")
 
-    if sum(1 for _ in jsonl_path.open("r", encoding="utf-8")) != len(result):
+    with jsonl_path.open("r", encoding="utf-8") as handle:
+        jsonl_row_count = sum(1 for _ in handle)
+    if jsonl_row_count != len(result):
         raise RuntimeError("ARTIFACT_VALIDATE_FAILED: jsonl row count mismatch")
     with pkl_path.open("rb") as handle:
         pickle.load(handle)
@@ -67,6 +73,7 @@ def write_processed_artifacts(
         chunk_count=len(result),
         jsonl_path=jsonl_path,
         pkl_path=pkl_path,
+        txt_path=txt_path,
         parser_profile=parser_profile,
         parser_version=parser_version,
         embedding=embedding,
@@ -81,10 +88,13 @@ def write_processed_artifacts(
         chunk_count=len(result),
         jsonl_name=jsonl_path.name,
         pkl_name=pkl_path.name,
+        txt_name=txt_path.name if txt_path is not None else None,
         jsonl_sha256=manifest["sha256"]["chunks_jsonl"],
         pkl_sha256=manifest["sha256"]["chunks_pkl"],
+        txt_sha256=manifest["sha256"].get("full_text_txt"),
         jsonl_size_bytes=manifest["size_bytes"]["chunks_jsonl"],
         pkl_size_bytes=manifest["size_bytes"]["chunks_pkl"],
+        txt_size_bytes=manifest["size_bytes"].get("full_text_txt"),
         manifest_hash=manifest_hash,
         manifest=manifest,
     )

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -18,10 +18,13 @@ class ArtifactInfo:
     chunk_count: int
     jsonl_name: str
     pkl_name: str
+    txt_name: str | None
     jsonl_sha256: str
     pkl_sha256: str
+    txt_sha256: str | None
     jsonl_size_bytes: int
     pkl_size_bytes: int
+    txt_size_bytes: int | None
     manifest_hash: str
     manifest: dict[str, Any]
 
@@ -40,12 +43,30 @@ def build_manifest(
     chunk_count: int,
     jsonl_path: Path,
     pkl_path: Path,
+    txt_path: Path | None,
     parser_profile: str,
     parser_version: str,
     embedding: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], str]:
     jsonl_name = jsonl_path.name
     pkl_name = pkl_path.name
+    artifacts = {
+        "chunks_jsonl": jsonl_name,
+        "chunks_pkl": pkl_name,
+    }
+    sha256 = {
+        "chunks_jsonl": file_sha256(jsonl_path),
+        "chunks_pkl": file_sha256(pkl_path),
+    }
+    size_bytes = {
+        "chunks_jsonl": jsonl_path.stat().st_size,
+        "chunks_pkl": pkl_path.stat().st_size,
+    }
+    if txt_path is not None:
+        artifacts["full_text_txt"] = txt_path.name
+        sha256["full_text_txt"] = file_sha256(txt_path)
+        size_bytes["full_text_txt"] = txt_path.stat().st_size
+
     manifest = {
         "document_id": snapshot.document_id,
         "document_version": snapshot.document_version,
@@ -55,18 +76,9 @@ def build_manifest(
         "collection_storage_path": snapshot.collection_storage_path,
         "processed_storage_path": snapshot.processed_storage_path,
         "chunk_count": chunk_count,
-        "artifacts": {
-            "chunks_jsonl": jsonl_name,
-            "chunks_pkl": pkl_name,
-        },
-        "sha256": {
-            "chunks_jsonl": file_sha256(jsonl_path),
-            "chunks_pkl": file_sha256(pkl_path),
-        },
-        "size_bytes": {
-            "chunks_jsonl": jsonl_path.stat().st_size,
-            "chunks_pkl": pkl_path.stat().st_size,
-        },
+        "artifacts": artifacts,
+        "sha256": sha256,
+        "size_bytes": size_bytes,
         "created_at": datetime.now(UTC).isoformat(),
         "producer": "kb-parse-worker",
         "parser_profile": parser_profile,
@@ -87,15 +99,21 @@ def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
 
 def load_artifact_info(manifest_path: Path, manifest_hash: str | None = None) -> ArtifactInfo:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    artifacts = manifest["artifacts"]
+    sha256 = manifest["sha256"]
+    size_bytes = manifest["size_bytes"]
     return ArtifactInfo(
         artifact_uuid=str(manifest["artifact_uuid"]),
         chunk_count=int(manifest["chunk_count"]),
-        jsonl_name=str(manifest["artifacts"]["chunks_jsonl"]),
-        pkl_name=str(manifest["artifacts"]["chunks_pkl"]),
-        jsonl_sha256=str(manifest["sha256"]["chunks_jsonl"]),
-        pkl_sha256=str(manifest["sha256"]["chunks_pkl"]),
-        jsonl_size_bytes=int(manifest["size_bytes"]["chunks_jsonl"]),
-        pkl_size_bytes=int(manifest["size_bytes"]["chunks_pkl"]),
+        jsonl_name=str(artifacts["chunks_jsonl"]),
+        pkl_name=str(artifacts["chunks_pkl"]),
+        txt_name=str(artifacts["full_text_txt"]) if artifacts.get("full_text_txt") else None,
+        jsonl_sha256=str(sha256["chunks_jsonl"]),
+        pkl_sha256=str(sha256["chunks_pkl"]),
+        txt_sha256=str(sha256["full_text_txt"]) if sha256.get("full_text_txt") else None,
+        jsonl_size_bytes=int(size_bytes["chunks_jsonl"]),
+        pkl_size_bytes=int(size_bytes["chunks_pkl"]),
+        txt_size_bytes=int(size_bytes["full_text_txt"]) if size_bytes.get("full_text_txt") is not None else None,
         manifest_hash=manifest_hash or file_sha256(manifest_path),
         manifest=manifest,
     )

--- a/src/kb_parse_worker/parser_adapter.py
+++ b/src/kb_parse_worker/parser_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -12,17 +13,42 @@ class ParserError(RuntimeError):
     pass
 
 
+@dataclass(frozen=True)
+class ParsedDocument:
+    result: list[Any]
+    txt: str | None
+    original_chunk_count: int
+    dropped_empty_text_count: int
+
+
+def _has_nonempty_text(item: Any) -> bool:
+    if isinstance(item, dict):
+        text = item.get("text")
+        return isinstance(text, str) and bool(text.strip())
+    if isinstance(item, str):
+        return bool(item.strip())
+    return True
+
+
+def filter_empty_text_chunks(result: list[Any]) -> tuple[list[Any], int]:
+    filtered = [item for item in result if _has_nonempty_text(item)]
+    return filtered, len(result) - len(filtered)
+
+
 def parse_with_unstructure_serve(
     raw_path: Path,
     api_url: str,
     bearer_token: str,
     timeout_seconds: int = 3600,
-) -> list[Any]:
+    return_txt: bool = True,
+) -> ParsedDocument:
     headers = {"Authorization": f"Bearer {bearer_token}"}
     with raw_path.open("rb") as handle:
         response = requests.post(
             api_url,
             files={"file": (raw_path.name, handle)},
+            params={"return_txt": "true" if return_txt else "false"},
+            data={"return_txt": "true" if return_txt else "false"},
             headers=headers,
             timeout=timeout_seconds,
         )
@@ -37,5 +63,15 @@ def parse_with_unstructure_serve(
     result = payload["result"]
     if not isinstance(result, list):
         raise ParserError("parser result must be a list")
-    return result
-
+    filtered_result, dropped_count = filter_empty_text_chunks(result)
+    txt = payload.get("txt")
+    if txt is not None and not isinstance(txt, str):
+        raise ParserError("parser txt must be a string when present")
+    if return_txt and txt is None:
+        raise ParserError("parser response missing txt")
+    return ParsedDocument(
+        result=filtered_result,
+        txt=txt,
+        original_chunk_count=len(result),
+        dropped_empty_text_count=dropped_count,
+    )

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -152,11 +152,19 @@ class ParseWorker:
                     _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
                     lease.check()
 
-                    result = parse_with_unstructure_serve(
+                    parsed = parse_with_unstructure_serve(
                         raw_path,
                         self.config.unstructure_serve_url,
                         self.config.unstructure_serve_bearer_token,
                     )
+                    result = parsed.result
+                    if parsed.dropped_empty_text_count:
+                        LOGGER.info(
+                            "parse job %s dropped %s empty text chunk(s) from %s parser chunk(s)",
+                            claimed.job_id,
+                            parsed.dropped_empty_text_count,
+                            parsed.original_chunk_count,
+                        )
                     lease.check()
 
                     result = add_chunk_embeddings(
@@ -184,6 +192,7 @@ class ParseWorker:
                         self.config.parser_profile,
                         self.config.parser_version,
                         embedding_metadata,
+                        parsed.txt,
                     )
                     lease.check()
 
@@ -194,6 +203,8 @@ class ParseWorker:
                             "parser_version": self.config.parser_version,
                             "chunk_count": artifact_info.chunk_count,
                             "artifact_uuid": artifact_info.artifact_uuid,
+                            "source_chunk_count": parsed.original_chunk_count,
+                            "dropped_empty_text_count": parsed.dropped_empty_text_count,
                             "embedding": embedding_metadata,
                         }
                     }

--- a/tests/test_kb_parse_worker_artifacts.py
+++ b/tests/test_kb_parse_worker_artifacts.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.kb_parse_worker.artifacts import write_processed_artifacts
+from src.kb_parse_worker.parser_adapter import (
+    ParserError,
+    filter_empty_text_chunks,
+    parse_with_unstructure_serve,
+)
+from src.kb_parse_worker.snapshot import ParseSnapshot
+
+
+def snapshot() -> ParseSnapshot:
+    return ParseSnapshot(
+        job_id="job-1",
+        document_id="00000000-0000-0000-0000-000000000001",
+        document_version=1,
+        document_status="parse_queued",
+        raw_uri="nas://kb/raw/course/demo/doc.pdf",
+        raw_storage_region=None,
+        file_ext=".pdf",
+        file_size=1,
+        sha256="sha",
+        original_filename="doc.pdf",
+        primary_collection_id="00000000-0000-0000-0000-000000000002",
+        collection_name="demo",
+        collection_path="/course/demo",
+        collection_storage_path="course/demo",
+        processed_storage_path="course_pickle/demo_pickle",
+        content_type="application/pdf",
+        collection_metadata_schema_json={},
+        document_metadata_json={},
+        job_payload_json={},
+        processed_manifest_local_uri=None,
+        processed_manifest_hash=None,
+        processed_artifact_uuid=None,
+        chunk_count=None,
+    )
+
+
+class KbParseWorkerArtifactTests(unittest.TestCase):
+    class FakeResponse:
+        status_code = 200
+        text = ""
+
+        def __init__(self, payload: dict) -> None:
+            self.payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self.payload
+
+    def test_filter_empty_text_chunks_drops_empty_text_dicts(self) -> None:
+        result, dropped = filter_empty_text_chunks(
+            [
+                {"text": " kept ", "page_number": 1},
+                {"text": "", "page_number": 2},
+                {"text": "   ", "page_number": 3},
+                {"content": "missing text", "page_number": 4},
+            ]
+        )
+
+        self.assertEqual(dropped, 3)
+        self.assertEqual(result, [{"text": " kept ", "page_number": 1}])
+
+    def test_parse_with_unstructure_serve_requests_txt_and_filters_result(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as raw_file:
+            raw_file.write(b"%PDF")
+            raw_file.flush()
+            response = self.FakeResponse(
+                {
+                    "result": [{"text": "chunk"}, {"text": ""}, {"text": "   "}],
+                    "txt": "whole document text",
+                }
+            )
+
+            with patch("src.kb_parse_worker.parser_adapter.requests.post", return_value=response) as post:
+                parsed = parse_with_unstructure_serve(
+                    Path(raw_file.name),
+                    "https://parser.test/mineru",
+                    "token",
+                )
+
+            self.assertEqual(parsed.result, [{"text": "chunk"}])
+            self.assertEqual(parsed.txt, "whole document text")
+            self.assertEqual(parsed.original_chunk_count, 3)
+            self.assertEqual(parsed.dropped_empty_text_count, 2)
+            self.assertEqual(post.call_args.kwargs["params"], {"return_txt": "true"})
+            self.assertEqual(post.call_args.kwargs["data"], {"return_txt": "true"})
+
+    def test_parse_with_unstructure_serve_requires_txt_by_default(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as raw_file:
+            raw_file.write(b"%PDF")
+            raw_file.flush()
+            response = self.FakeResponse({"result": [{"text": "chunk"}]})
+
+            with patch("src.kb_parse_worker.parser_adapter.requests.post", return_value=response):
+                with self.assertRaisesRegex(ParserError, "missing txt"):
+                    parse_with_unstructure_serve(
+                        Path(raw_file.name),
+                        "https://parser.test/mineru",
+                        "token",
+                    )
+
+    def test_write_processed_artifacts_writes_full_text_txt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            final_dir, artifact_info = write_processed_artifacts(
+                [{"text": "chunk", "page_number": 1, "embedding": [0.1, 0.2]}],
+                snapshot(),
+                Path(temp_dir),
+                "profile",
+                "version",
+                {"model": "embedding"},
+                "whole document text",
+            )
+
+            manifest_path = final_dir / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            txt_name = manifest["artifacts"]["full_text_txt"]
+
+            self.assertEqual(txt_name, f"{manifest['artifact_uuid']}.txt")
+            self.assertEqual((final_dir / txt_name).read_text(encoding="utf-8"), "whole document text")
+            self.assertEqual(artifact_info.txt_name, txt_name)
+            self.assertEqual(manifest["size_bytes"]["full_text_txt"], len("whole document text"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- requests `return_txt=true` from Unstructure-Serve and stores the returned full text as `{artifact_uuid}.txt`
- filters empty/blank `text` chunks before embedding and pickle artifact generation
- records txt artifact metadata plus source/dropped chunk counts in manifests/docs

Closes #20.

## Validation
- ./.venv/bin/python -m compileall src/kb_parse_worker tests
- ./.venv/bin/python -m unittest discover -s tests -p "test_*.py"
- docpact validate-config --root . --strict
- docpact lint --root . --worktree --mode enforce

## Notes
- `python3 -m pytest tests` was not run because pytest is not installed in the repo-local venv; the added tests use stdlib unittest and passed.
- This PR intentionally does not modify TianGong-AI-Unstructure-Serve.