### PR TITLE
Harden KB parse and S3-ready worker failures

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-10"
-lastReviewedCommit: "163c1c726891c17cba2ef3442e96b92af593ef6b"
+lastReviewedAt: "2026-05-11"
+lastReviewedCommit: "6b01a5c1124541a3968557fa5dca03e976ab29fb"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -69,6 +69,10 @@ the referenced files still exist.
   verifies the processed manifest/jsonl/pkl/txt objects after NAS-to-S3 sync and
   calls `complete_s3_ready_check(...)` to mark `processed_s3_ready`. PM2 keeps
   both long-running worker processes resident; each worker's heartbeat loop
-  keeps its active job lock and PGMQ visibility timeout fresh.
+  keeps its active job lock and PGMQ visibility timeout fresh. Parse and
+  S3-ready jobs also enforce worker-local hard timeouts, classify failures as
+  retryable or terminal before calling `fail_job(...)`, and immediately archive
+  the queue message when the control plane returns `dead` so terminal documents
+  do not keep resurfacing in PGMQ.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -156,6 +156,7 @@ fresh through `heartbeat_job(...)`. The worker defaults to:
 
 ```text
 KB_PARSE_HEARTBEAT_INTERVAL_SECONDS=60
+KB_PARSE_JOB_TIMEOUT_SECONDS=7200
 ```
 
 Raw and processed artifact paths are derived from the collection storage path.
@@ -174,12 +175,23 @@ waits for the NAS sync layer to publish processed artifacts to S3 before calling
 ```text
 KB_PARSE_S3_READY_TIMEOUT_SECONDS=900
 KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS=15
+KB_PARSE_S3_READY_JOB_TIMEOUT_SECONDS=1200
 ```
 
 For deployments where NAS-to-S3 sync can take a long time, keep the parse worker
 and S3-ready worker as separate PM2 processes. Retry attempts for the S3-ready
 stage reuse `processed_manifest_local_uri` and only re-check processed S3
 readiness; they do not parse the document again.
+
+Worker failures are classified before calling `fail_job(...)`. Terminal parse
+failures such as `RAW_HASH_MISMATCH`, `RAW_STORAGE_PATH_MISMATCH`, malformed
+parser responses, empty parse results, and embedding schema/dimension errors are
+reported with `retryable=false`. Transient parser, embedding, DB, timeout, and
+network failures remain retryable. Terminal S3-ready failures include missing
+local manifests, manifest identity mismatches, and strict sha256 artifact
+mismatches; ordinary S3 sync delays remain retryable. When `fail_job(...)`
+returns `dead`, the worker archives the PGMQ message immediately so a terminal
+document does not keep resurfacing after the visibility timeout.
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3
 sync is intentionally unavailable.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -18,6 +18,13 @@ def _int_env(name: str, default: int) -> int:
     return int(value)
 
 
+def _positive_int_env(name: str, default: int) -> int:
+    value = _int_env(name, default)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive.")
+    return value
+
+
 def _bool_env(name: str, default: bool = False) -> bool:
     value = os.getenv(name)
     if value is None or value == "":
@@ -84,6 +91,8 @@ class WorkerConfig:
     embedding_dimensions: int
     embedding_batch_size: int
     embedding_timeout_seconds: int
+    parse_job_timeout_seconds: int
+    s3_ready_job_timeout_seconds: int
 
     @classmethod
     def from_env(cls) -> "WorkerConfig":
@@ -101,16 +110,17 @@ class WorkerConfig:
             raise ValueError("NAS_RAW_ROOT is required.")
         if not nas_processed_root:
             raise ValueError("NAS_PROCESSED_ROOT is required.")
+        s3_ready_timeout_seconds = _positive_int_env("KB_PARSE_S3_READY_TIMEOUT_SECONDS", 900)
 
         return cls(
             database_url=database_url_from_env(),
             worker_id=worker_id,
             queue_name=os.getenv("KB_PARSE_QUEUE", "kb_parse_queue"),
             s3_ready_queue_name=os.getenv("KB_S3_READY_QUEUE", "kb_s3_ready_queue"),
-            queue_vt_seconds=_int_env("KB_PARSE_QUEUE_VT_SECONDS", 1800),
-            lock_seconds=_int_env("KB_PARSE_LOCK_SECONDS", 1800),
-            heartbeat_interval_seconds=_int_env("KB_PARSE_HEARTBEAT_INTERVAL_SECONDS", 60),
-            poll_interval_seconds=_int_env("KB_PARSE_POLL_INTERVAL_SECONDS", 5),
+            queue_vt_seconds=_positive_int_env("KB_PARSE_QUEUE_VT_SECONDS", 1800),
+            lock_seconds=_positive_int_env("KB_PARSE_LOCK_SECONDS", 1800),
+            heartbeat_interval_seconds=_positive_int_env("KB_PARSE_HEARTBEAT_INTERVAL_SECONDS", 60),
+            poll_interval_seconds=_positive_int_env("KB_PARSE_POLL_INTERVAL_SECONDS", 5),
             nas_raw_root=Path(nas_raw_root),
             nas_processed_root=Path(nas_processed_root),
             unstructure_serve_url=unstructure_url,
@@ -121,12 +131,18 @@ class WorkerConfig:
             s3_bucket=os.getenv("KB_PROCESSED_S3_BUCKET", "tiangong"),
             s3_processed_prefix=os.getenv("KB_PROCESSED_S3_PREFIX", "processed_docs"),
             s3_strict_hash=_bool_env("KB_PARSE_S3_STRICT_HASH", False),
-            s3_ready_timeout_seconds=_int_env("KB_PARSE_S3_READY_TIMEOUT_SECONDS", 900),
-            s3_ready_poll_interval_seconds=_int_env("KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS", 15),
+            s3_ready_timeout_seconds=s3_ready_timeout_seconds,
+            s3_ready_poll_interval_seconds=_positive_int_env(
+                "KB_PARSE_S3_READY_POLL_INTERVAL_SECONDS", 15
+            ),
             embedding_base_url=os.getenv("KB_EMBEDDING_BASE_URL", "http://192.168.1.140:7710/v1"),
             embedding_model=os.getenv("KB_EMBEDDING_MODEL", "Qwen/Qwen3-Embedding-8B"),
             embedding_api_key=os.getenv("KB_EMBEDDING_API_KEY", "EMPTY"),
-            embedding_dimensions=_int_env("KB_EMBEDDING_DIMENSIONS", 1536),
-            embedding_batch_size=_int_env("KB_EMBEDDING_BATCH_SIZE", 32),
-            embedding_timeout_seconds=_int_env("KB_EMBEDDING_TIMEOUT_SECONDS", 600),
+            embedding_dimensions=_positive_int_env("KB_EMBEDDING_DIMENSIONS", 1536),
+            embedding_batch_size=_positive_int_env("KB_EMBEDDING_BATCH_SIZE", 32),
+            embedding_timeout_seconds=_positive_int_env("KB_EMBEDDING_TIMEOUT_SECONDS", 600),
+            parse_job_timeout_seconds=_positive_int_env("KB_PARSE_JOB_TIMEOUT_SECONDS", 7200),
+            s3_ready_job_timeout_seconds=_positive_int_env(
+                "KB_PARSE_S3_READY_JOB_TIMEOUT_SECONDS", s3_ready_timeout_seconds + 300
+            ),
         )

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -27,6 +27,13 @@ class S3ReadyEnqueueResult:
     document_status: str
 
 
+@dataclass(frozen=True)
+class FailJobResult:
+    job_id: str
+    job_status: str
+    document_status: str
+
+
 def connect(database_url: str):
     return psycopg2.connect(database_url)
 
@@ -85,13 +92,21 @@ def fail_job(
     retryable: bool,
     error: str,
     error_stage: str = "parse",
-) -> None:
-    with conn.cursor() as cur:
+) -> FailJobResult | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             "select * from public.fail_job(%s, %s, %s, %s, %s)",
             (job_id, worker_id, retryable, error[:2000], error_stage),
         )
+        row = cur.fetchone()
     conn.commit()
+    if row is None:
+        return None
+    return FailJobResult(
+        job_id=str(row["job_id"]),
+        job_status=str(row["job_status"]),
+        document_status=str(row["document_status"]),
+    )
 
 
 def mark_parse_local_ready(

--- a/src/kb_parse_worker/embedding_client.py
+++ b/src/kb_parse_worker/embedding_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Callable
 from typing import Any
 
 import requests
@@ -94,6 +95,7 @@ def add_chunk_embeddings(
     dimensions: int,
     batch_size: int,
     timeout_seconds: int,
+    deadline_check: Callable[[], None] | None = None,
 ) -> list[dict[str, Any]]:
     if dimensions <= 0:
         raise ValueError("KB_EMBEDDING_DIMENSIONS must be positive")
@@ -103,6 +105,8 @@ def add_chunk_embeddings(
     texts = [_chunk_text(item) for item in chunks]
     embedded_chunks: list[dict[str, Any]] = []
     for offset in range(0, len(chunks), batch_size):
+        if deadline_check is not None:
+            deadline_check()
         batch_chunks = chunks[offset : offset + batch_size]
         batch_texts = texts[offset : offset + batch_size]
         vectors = _embed_text_batch(
@@ -117,4 +121,6 @@ def add_chunk_embeddings(
             chunk = dict(item)
             chunk["embedding"] = vector
             embedded_chunks.append(chunk)
+        if deadline_check is not None:
+            deadline_check()
     return embedded_chunks

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -8,12 +8,14 @@ import threading
 import time
 from pathlib import Path
 
+import requests
+
 from . import control_plane, queue
 from .artifacts import write_processed_artifacts
 from .config import WorkerConfig
-from .embedding_client import add_chunk_embeddings
+from .embedding_client import EmbeddingError, add_chunk_embeddings
 from .manifest import load_artifact_info
-from .parser_adapter import parse_with_unstructure_serve
+from .parser_adapter import ParserError, parse_with_unstructure_serve
 from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
 from .snapshot import (
     load_parse_snapshot,
@@ -23,6 +25,99 @@ from .snapshot import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+class JobTimeout(RuntimeError):
+    pass
+
+
+class JobDeadline:
+    def __init__(self, stage: str, timeout_seconds: int):
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self.stage = stage
+        self.timeout_seconds = timeout_seconds
+        self.deadline = time.monotonic() + timeout_seconds
+
+    def check(self) -> None:
+        if time.monotonic() >= self.deadline:
+            raise JobTimeout(f"{self.stage.upper()}_JOB_TIMEOUT_AFTER_{self.timeout_seconds}s")
+
+    def remaining_seconds(self, maximum: int | None = None) -> int:
+        self.check()
+        remaining = max(1, int(self.deadline - time.monotonic()))
+        if maximum is not None:
+            return max(1, min(maximum, remaining))
+        return remaining
+
+
+def _http_status_from_message(prefix: str, message: str) -> int | None:
+    if not message.startswith(prefix):
+        return None
+    try:
+        return int(message.removeprefix(prefix).split(":", 1)[0].strip())
+    except ValueError:
+        return None
+
+
+def _is_retryable_http_status(status: int | None) -> bool:
+    return status is not None and (status == 429 or status >= 500)
+
+
+def is_parse_failure_retryable(error: Exception) -> bool:
+    if isinstance(error, JobTimeout):
+        return True
+    if isinstance(error, requests.RequestException):
+        return True
+
+    message = str(error)
+    if message in {"RAW_HASH_MISMATCH", "EMPTY_RESULT", "EMBEDDING_CHUNK_NOT_OBJECT"}:
+        return False
+    if message.startswith("RAW_STORAGE_PATH_MISMATCH"):
+        return False
+    if message.startswith("EMBEDDING_DIMENSION_TOO_SMALL"):
+        return False
+    if message.startswith("parser response ") or message.startswith("parser result "):
+        return False
+    if message.startswith("embedding response "):
+        return False
+
+    if isinstance(error, ParserError):
+        return _is_retryable_http_status(_http_status_from_message("parser http error ", message))
+    if isinstance(error, EmbeddingError):
+        status = _http_status_from_message("embedding http error ", message)
+        return status is None or _is_retryable_http_status(status)
+
+    return True
+
+
+def is_s3_ready_failure_retryable(error: Exception) -> bool:
+    if isinstance(error, JobTimeout):
+        return True
+
+    message = str(error)
+    if message in {"LOCAL_MANIFEST_MISSING"}:
+        return False
+    if "S3_MANIFEST_MISMATCH" in message:
+        return False
+    if "S3_ARTIFACT_MISMATCH" in message and "sha256" in message:
+        return False
+
+    return True
+
+
+def fail_job_and_archive_if_dead(
+    conn,
+    job_id: str,
+    worker_id: str,
+    retryable: bool,
+    error: str,
+    error_stage: str,
+) -> control_plane.FailJobResult | None:
+    result = control_plane.fail_job(conn, job_id, worker_id, retryable, error, error_stage)
+    if result is not None and result.job_status == "dead":
+        queue.archive_job_message(conn, job_id, worker_id)
+    return result
 
 
 def _sha256(path: Path) -> str:
@@ -121,12 +216,20 @@ class ParseWorker:
             queue.archive_job_message(conn, message.job_id, self.config.worker_id)
             return
         if claimed.stage != "parse":
-            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, False, "UNSUPPORTED_STAGE")
-            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+            fail_job_and_archive_if_dead(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                False,
+                "UNSUPPORTED_STAGE",
+                "parse",
+            )
             return
 
         try:
             with LeaseMaintainer(self.config, claimed.job_id) as lease:
+                deadline = JobDeadline("parse", self.config.parse_job_timeout_seconds)
+                deadline.check()
                 snapshot = load_parse_snapshot(conn, claimed.job_id)
                 if snapshot.processed_manifest_local_uri and snapshot.processed_artifact_uuid:
                     manifest_path = Path(snapshot.processed_manifest_local_uri)
@@ -147,15 +250,20 @@ class ParseWorker:
                         }
                     }
                 else:
+                    deadline.check()
                     raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
                     validate_raw_storage_path(snapshot, raw_path, self.config.nas_raw_root)
                     _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
                     lease.check()
+                    deadline.check()
 
                     parsed = parse_with_unstructure_serve(
                         raw_path,
                         self.config.unstructure_serve_url,
                         self.config.unstructure_serve_bearer_token,
+                        timeout_seconds=deadline.remaining_seconds(
+                            self.config.parse_job_timeout_seconds
+                        ),
                     )
                     result = parsed.result
                     if parsed.dropped_empty_text_count:
@@ -166,6 +274,7 @@ class ParseWorker:
                             parsed.original_chunk_count,
                         )
                     lease.check()
+                    deadline.check()
 
                     result = add_chunk_embeddings(
                         result,
@@ -174,9 +283,11 @@ class ParseWorker:
                         self.config.embedding_api_key,
                         self.config.embedding_dimensions,
                         self.config.embedding_batch_size,
-                        self.config.embedding_timeout_seconds,
+                        deadline.remaining_seconds(self.config.embedding_timeout_seconds),
+                        deadline.check,
                     )
                     lease.check()
+                    deadline.check()
 
                     embedding_metadata = {
                         "model": self.config.embedding_model,
@@ -195,6 +306,7 @@ class ParseWorker:
                         parsed.txt,
                     )
                     lease.check()
+                    deadline.check()
 
                     manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
                     metadata_json = {
@@ -244,11 +356,15 @@ class ParseWorker:
                 queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
         except Exception as exc:
             LOGGER.exception("parse job %s failed", claimed.job_id)
-            retryable = str(exc) not in {
-                "RAW_HASH_MISMATCH",
-                "EMPTY_RESULT",
-            } and not str(exc).startswith("RAW_STORAGE_PATH_MISMATCH")
-            control_plane.fail_job(conn, claimed.job_id, self.config.worker_id, retryable, str(exc))
+            retryable = is_parse_failure_retryable(exc)
+            fail_job_and_archive_if_dead(
+                conn,
+                claimed.job_id,
+                self.config.worker_id,
+                retryable,
+                str(exc),
+                "parse",
+            )
 
 
 class S3ReadyWorker:
@@ -287,7 +403,7 @@ class S3ReadyWorker:
             queue.archive_job_message(conn, message.job_id, self.config.worker_id)
             return
         if claimed.stage != "s3_ready":
-            control_plane.fail_job(
+            fail_job_and_archive_if_dead(
                 conn,
                 claimed.job_id,
                 self.config.worker_id,
@@ -295,17 +411,19 @@ class S3ReadyWorker:
                 "UNSUPPORTED_STAGE",
                 "s3_ready",
             )
-            queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
             return
 
         try:
             with LeaseMaintainer(self.config, claimed.job_id) as lease:
+                deadline = JobDeadline("s3_ready", self.config.s3_ready_job_timeout_seconds)
+                deadline.check()
                 snapshot = load_s3_ready_snapshot(conn, claimed.job_id)
                 if not snapshot.processed_manifest_local_uri:
                     raise RuntimeError("LOCAL_MANIFEST_MISSING")
                 manifest_path = Path(snapshot.processed_manifest_local_uri)
                 artifact_info = load_artifact_info(manifest_path, snapshot.processed_manifest_hash)
                 lease.check()
+                deadline.check()
 
                 if self.config.s3_ready_mode == "skip":
                     manifest_s3_key = processed_manifest_key(self.config.s3_processed_prefix, snapshot)
@@ -318,11 +436,12 @@ class S3ReadyWorker:
                         self.config.s3_bucket,
                         self.config.s3_processed_prefix,
                         self.config.s3_strict_hash,
-                        self.config.s3_ready_timeout_seconds,
+                        deadline.remaining_seconds(self.config.s3_ready_timeout_seconds),
                         self.config.s3_ready_poll_interval_seconds,
                     )
                     manifest_s3_key = ready.manifest_s3_key
                 lease.check()
+                deadline.check()
 
                 ok = control_plane.complete_s3_ready_check(
                     conn,
@@ -341,11 +460,12 @@ class S3ReadyWorker:
                 queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
         except Exception as exc:
             LOGGER.exception("s3_ready job %s failed", claimed.job_id)
-            control_plane.fail_job(
+            retryable = is_s3_ready_failure_retryable(exc)
+            fail_job_and_archive_if_dead(
                 conn,
                 claimed.job_id,
                 self.config.worker_id,
-                True,
+                retryable,
                 str(exc),
                 "s3_ready",
             )

--- a/tests/test_kb_parse_worker_reliability.py
+++ b/tests/test_kb_parse_worker_reliability.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.kb_parse_worker import control_plane, queue
+from src.kb_parse_worker.worker import (
+    JobTimeout,
+    ParseWorker,
+    S3ReadyWorker,
+    is_parse_failure_retryable,
+    is_s3_ready_failure_retryable,
+)
+
+
+class NoopLease:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def __enter__(self) -> "NoopLease":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        return None
+
+    def check(self) -> None:
+        return None
+
+
+def worker_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        database_url="postgresql://test",
+        worker_id="worker-1",
+        queue_name="kb_parse_queue",
+        s3_ready_queue_name="kb_s3_ready_queue",
+        queue_vt_seconds=30,
+        lock_seconds=30,
+        heartbeat_interval_seconds=1,
+        poll_interval_seconds=1,
+        parse_job_timeout_seconds=60,
+        s3_ready_job_timeout_seconds=60,
+        s3_ready_mode="check",
+        s3_bucket="tiangong",
+        s3_processed_prefix="processed_docs",
+        s3_strict_hash=False,
+        s3_ready_timeout_seconds=30,
+        s3_ready_poll_interval_seconds=1,
+    )
+
+
+def claimed(stage: str) -> control_plane.ClaimedJob:
+    return control_plane.ClaimedJob(
+        job_id="job-1",
+        document_id="00000000-0000-0000-0000-000000000001",
+        document_version=1,
+        stage=stage,
+        status="running",
+        payload_json={},
+    )
+
+
+def message() -> queue.QueueMessage:
+    return queue.QueueMessage(msg_id=1, job_id="job-1", raw_payload={"job_id": "job-1"})
+
+
+class KbParseWorkerReliabilityTests(unittest.TestCase):
+    def test_parse_failure_classifier_distinguishes_terminal_and_transient(self) -> None:
+        self.assertFalse(is_parse_failure_retryable(RuntimeError("EMPTY_RESULT")))
+        self.assertFalse(is_parse_failure_retryable(RuntimeError("RAW_STORAGE_PATH_MISMATCH: path")))
+        self.assertTrue(is_parse_failure_retryable(RuntimeError("temporary parser outage")))
+        self.assertTrue(is_parse_failure_retryable(JobTimeout("PARSE_JOB_TIMEOUT_AFTER_60s")))
+
+    def test_s3_ready_failure_classifier_distinguishes_terminal_and_transient(self) -> None:
+        self.assertFalse(is_s3_ready_failure_retryable(RuntimeError("LOCAL_MANIFEST_MISSING")))
+        self.assertFalse(
+            is_s3_ready_failure_retryable(RuntimeError("S3_MANIFEST_MISMATCH: document_id"))
+        )
+        self.assertFalse(
+            is_s3_ready_failure_retryable(RuntimeError("S3_ARTIFACT_MISMATCH: chunks.pkl sha256"))
+        )
+        self.assertTrue(
+            is_s3_ready_failure_retryable(RuntimeError("S3_NOT_READY_AFTER_TIMEOUT: not synced"))
+        )
+        self.assertTrue(is_s3_ready_failure_retryable(JobTimeout("S3_READY_JOB_TIMEOUT_AFTER_60s")))
+
+    def test_parse_terminal_failure_marks_non_retryable_and_archives_dead_job(self) -> None:
+        conn = object()
+        fail_result = control_plane.FailJobResult(
+            job_id="job-1",
+            job_status="dead",
+            document_status="failed",
+        )
+        with (
+            patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch("src.kb_parse_worker.worker.control_plane.claim_job", return_value=claimed("parse")),
+            patch("src.kb_parse_worker.worker.load_parse_snapshot", side_effect=RuntimeError("EMPTY_RESULT")),
+            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.LOGGER.exception"),
+        ):
+            ParseWorker(worker_config()).process_message(conn, message())
+
+        fail_job.assert_called_once()
+        self.assertFalse(fail_job.call_args.args[3])
+        archive.assert_called_once_with(conn, "job-1", "worker-1")
+
+    def test_parse_timeout_marks_retryable_without_archiving_failed_job(self) -> None:
+        conn = object()
+        fail_result = control_plane.FailJobResult(
+            job_id="job-1",
+            job_status="failed",
+            document_status="parse_queued",
+        )
+        with (
+            patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch("src.kb_parse_worker.worker.control_plane.claim_job", return_value=claimed("parse")),
+            patch(
+                "src.kb_parse_worker.worker.load_parse_snapshot",
+                side_effect=JobTimeout("PARSE_JOB_TIMEOUT_AFTER_60s"),
+            ),
+            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.LOGGER.exception"),
+        ):
+            ParseWorker(worker_config()).process_message(conn, message())
+
+        fail_job.assert_called_once()
+        self.assertTrue(fail_job.call_args.args[3])
+        archive.assert_not_called()
+
+    def test_s3_ready_terminal_failure_marks_non_retryable_and_archives_dead_job(self) -> None:
+        conn = object()
+        fail_result = control_plane.FailJobResult(
+            job_id="job-1",
+            job_status="dead",
+            document_status="failed",
+        )
+        with (
+            patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch(
+                "src.kb_parse_worker.worker.control_plane.claim_job",
+                return_value=claimed("s3_ready"),
+            ),
+            patch(
+                "src.kb_parse_worker.worker.load_s3_ready_snapshot",
+                return_value=SimpleNamespace(processed_manifest_local_uri=None),
+            ),
+            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.LOGGER.exception"),
+        ):
+            S3ReadyWorker(worker_config()).process_message(conn, message())
+
+        fail_job.assert_called_once()
+        self.assertFalse(fail_job.call_args.args[3])
+        archive.assert_called_once()
+
+    def test_s3_ready_transient_failure_marks_retryable_without_archiving_failed_job(self) -> None:
+        conn = object()
+        fail_result = control_plane.FailJobResult(
+            job_id="job-1",
+            job_status="failed",
+            document_status="s3_ready_check_failed",
+        )
+        with (
+            patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch(
+                "src.kb_parse_worker.worker.control_plane.claim_job",
+                return_value=claimed("s3_ready"),
+            ),
+            patch(
+                "src.kb_parse_worker.worker.load_s3_ready_snapshot",
+                side_effect=RuntimeError("S3_NOT_READY_AFTER_TIMEOUT: sync delay"),
+            ),
+            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.LOGGER.exception"),
+        ):
+            S3ReadyWorker(worker_config()).process_message(conn, message())
+
+        fail_job.assert_called_once()
+        self.assertTrue(fail_job.call_args.args[3])
+        archive.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds worker-local hard deadlines for parse and S3-ready jobs.
- Classifies parse and S3-ready failures before calling `fail_job(...)` so terminal failures use `retryable=false`.
- Parses `fail_job(...)` return state and immediately archives the PGMQ message when the job becomes `dead`.
- Adds reliability tests for terminal/transient classification, timeout failure handling, and dead-message archive behavior.
- Updates repo docs/runbook with timeout env vars and failure handling semantics.

Closes #23.

## Validation

- `.venv/bin/python -m compileall src/kb_parse_worker`
- `.venv/bin/python -m unittest discover -s tests`
- `docpact validate-config --root . --strict`
- `docpact lint --root . --worktree --mode enforce`

## Notes

PM2 still only handles process supervision. This change makes the worker write document/job failure state explicitly and archive dead messages so terminal documents do not keep resurfacing after PGMQ visibility timeout.
