### PR TITLE
[codex] harden KB worker retry wakeups

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-11"
-lastReviewedCommit: "6b01a5c1124541a3968557fa5dca03e976ab29fb"
+lastReviewedCommit: "0fff3e2c5fde4757d2b285f4781ae12182946b35"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - docker/**
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Unstructure Architecture
@@ -70,9 +70,12 @@ the referenced files still exist.
   calls `complete_s3_ready_check(...)` to mark `processed_s3_ready`. PM2 keeps
   both long-running worker processes resident; each worker's heartbeat loop
   keeps its active job lock and PGMQ visibility timeout fresh. Parse and
-  S3-ready jobs also enforce worker-local hard timeouts, classify failures as
-  retryable or terminal before calling `fail_job(...)`, and immediately archive
-  the queue message when the control plane returns `dead` so terminal documents
-  do not keep resurfacing in PGMQ.
+  S3-ready jobs also enforce worker-local hard timeouts, consume typed
+  `claim_job_from_pgmq_message(...)` dispositions, classify failures as
+  retryable or terminal before calling `fail_job_v2(...)`, and archive the
+  current PGMQ message by queue/message id only when the control plane contract
+  says the current wake-up should be removed. Retryable failures archive the
+  current transport message after `fail_job_v2(...)` schedules the delayed
+  retry wake-up.
 - Edge functions query indexes or storage populated by these workflows, but API
   serving remains outside this repository.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,7 +14,7 @@ checkPaths:
   - src/**
   - requirements.txt
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: 163c1c726891c17cba2ef3442e96b92af593ef6b
+lastReviewedAt: 2026-05-11
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Unstructure Development Runbook
@@ -183,15 +183,18 @@ and S3-ready worker as separate PM2 processes. Retry attempts for the S3-ready
 stage reuse `processed_manifest_local_uri` and only re-check processed S3
 readiness; they do not parse the document again.
 
-Worker failures are classified before calling `fail_job(...)`. Terminal parse
+Worker failures are classified before calling `fail_job_v2(...)`. Terminal parse
 failures such as `RAW_HASH_MISMATCH`, `RAW_STORAGE_PATH_MISMATCH`, malformed
 parser responses, empty parse results, and embedding schema/dimension errors are
 reported with `retryable=false`. Transient parser, embedding, DB, timeout, and
 network failures remain retryable. Terminal S3-ready failures include missing
 local manifests, manifest identity mismatches, and strict sha256 artifact
-mismatches; ordinary S3 sync delays remain retryable. When `fail_job(...)`
-returns `dead`, the worker archives the PGMQ message immediately so a terminal
-document does not keep resurfacing after the visibility timeout.
+mismatches; ordinary S3 sync delays remain retryable. Retryable failure calls
+schedule delayed retry wake-up messages in the KB control plane, so the worker
+archives the current PGMQ transport message by queue/message id after
+`fail_job_v2(...)` returns. Claim dispositions such as `backoff_not_due`,
+`cancelled`, `dead`, and duplicate wake-ups are archived only when
+`archive_current_message` is true.
 
 Use `KB_PARSE_S3_READY_MODE=skip` only for local smoke runs where processed S3
 sync is intentionally unavailable.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -12,7 +12,7 @@ checkPaths:
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
 lastReviewedAt: 2026-05-11
-lastReviewedCommit: 6b01a5c1124541a3968557fa5dca03e976ab29fb
+lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -19,6 +19,24 @@ class ClaimedJob:
 
 
 @dataclass(frozen=True)
+class ClaimJobResult:
+    claim_status: str
+    archive_current_message: bool
+    job_id: str
+    document_id: str | None
+    document_version: int | None
+    stage: str | None
+    status: str | None
+    payload_json: dict
+    next_retry_at: str | None
+    retry_wakeup_msg_id: int | None
+
+    @property
+    def claimed(self) -> bool:
+        return self.claim_status == "claimed"
+
+
+@dataclass(frozen=True)
 class S3ReadyEnqueueResult:
     parse_job_id: str
     parse_job_status: str
@@ -32,6 +50,8 @@ class FailJobResult:
     job_id: str
     job_status: str
     document_status: str
+    next_retry_at: str | None = None
+    retry_wakeup_msg_id: int | None = None
 
 
 def connect(database_url: str):
@@ -45,12 +65,12 @@ def claim_job(
     msg_id: int,
     worker_id: str,
     lock_seconds: int,
-) -> ClaimedJob | None:
+) -> ClaimJobResult | None:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
             select *
-            from public.start_job_from_pgmq_message(%s, %s, %s, %s, %s)
+            from public.claim_job_from_pgmq_message(%s, %s, %s, %s, %s)
             """,
             (job_id, queue_name, msg_id, worker_id, lock_seconds),
         )
@@ -58,13 +78,19 @@ def claim_job(
     conn.commit()
     if row is None:
         return None
-    return ClaimedJob(
+    return ClaimJobResult(
+        claim_status=str(row["claim_status"]),
+        archive_current_message=bool(row["archive_current_message"]),
         job_id=str(row["job_id"]),
-        document_id=str(row["document_id"]),
-        document_version=int(row["document_version"]),
-        stage=str(row["stage"]),
-        status=str(row["status"]),
+        document_id=str(row["document_id"]) if row["document_id"] is not None else None,
+        document_version=int(row["document_version"]) if row["document_version"] is not None else None,
+        stage=str(row["stage"]) if row["stage"] is not None else None,
+        status=str(row["status"]) if row["status"] is not None else None,
         payload_json=dict(row["payload_json"] or {}),
+        next_retry_at=row["next_retry_at"].isoformat() if row["next_retry_at"] is not None else None,
+        retry_wakeup_msg_id=(
+            int(row["retry_wakeup_msg_id"]) if row["retry_wakeup_msg_id"] is not None else None
+        ),
     )
 
 
@@ -95,7 +121,7 @@ def fail_job(
 ) -> FailJobResult | None:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
-            "select * from public.fail_job(%s, %s, %s, %s, %s)",
+            "select * from public.fail_job_v2(%s, %s, %s, %s, %s)",
             (job_id, worker_id, retryable, error[:2000], error_stage),
         )
         row = cur.fetchone()
@@ -106,6 +132,10 @@ def fail_job(
         job_id=str(row["job_id"]),
         job_status=str(row["job_status"]),
         document_status=str(row["document_status"]),
+        next_retry_at=row["next_retry_at"].isoformat() if row["next_retry_at"] is not None else None,
+        retry_wakeup_msg_id=(
+            int(row["retry_wakeup_msg_id"]) if row["retry_wakeup_msg_id"] is not None else None
+        ),
     )
 
 

--- a/src/kb_parse_worker/queue.py
+++ b/src/kb_parse_worker/queue.py
@@ -39,3 +39,10 @@ def archive_job_message(conn, job_id: str, worker_id: str | None = None) -> bool
     conn.commit()
     return bool(row and row[0])
 
+
+def archive_job_message_by_id(conn, queue_name: str, msg_id: int) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("select public.archive_job_message_by_id(%s, %s)", (queue_name, msg_id))
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -106,17 +106,52 @@ def is_s3_ready_failure_retryable(error: Exception) -> bool:
     return True
 
 
-def fail_job_and_archive_if_dead(
+def archive_current_message(conn, queue_name: str, msg_id: int) -> bool:
+    return queue.archive_job_message_by_id(conn, queue_name, msg_id)
+
+
+def handle_unclaimed_message(
+    conn,
+    queue_name: str,
+    message: queue.QueueMessage,
+    claim: control_plane.ClaimJobResult | None,
+) -> None:
+    if claim is None:
+        LOGGER.warning("job %s returned no claim disposition", message.job_id)
+        return
+    LOGGER.info(
+        "job %s was not claimed status=%s archive_current_message=%s next_retry_at=%s retry_wakeup_msg_id=%s",
+        message.job_id,
+        claim.claim_status,
+        claim.archive_current_message,
+        claim.next_retry_at,
+        claim.retry_wakeup_msg_id,
+    )
+    if claim.archive_current_message:
+        archive_current_message(conn, queue_name, message.msg_id)
+
+
+def fail_job_and_archive_current_message(
     conn,
     job_id: str,
+    queue_name: str,
+    msg_id: int,
     worker_id: str,
     retryable: bool,
     error: str,
     error_stage: str,
 ) -> control_plane.FailJobResult | None:
     result = control_plane.fail_job(conn, job_id, worker_id, retryable, error, error_stage)
-    if result is not None and result.job_status == "dead":
-        queue.archive_job_message(conn, job_id, worker_id)
+    if result is not None:
+        LOGGER.info(
+            "job %s failed status=%s retryable=%s next_retry_at=%s retry_wakeup_msg_id=%s",
+            job_id,
+            result.job_status,
+            retryable,
+            result.next_retry_at,
+            result.retry_wakeup_msg_id,
+        )
+        archive_current_message(conn, queue_name, msg_id)
     return result
 
 
@@ -211,14 +246,15 @@ class ParseWorker:
             self.config.worker_id,
             self.config.lock_seconds,
         )
-        if claimed is None:
-            LOGGER.info("job %s was not claimable", message.job_id)
-            queue.archive_job_message(conn, message.job_id, self.config.worker_id)
+        if claimed is None or not claimed.claimed:
+            handle_unclaimed_message(conn, self.config.queue_name, message, claimed)
             return
         if claimed.stage != "parse":
-            fail_job_and_archive_if_dead(
+            fail_job_and_archive_current_message(
                 conn,
                 claimed.job_id,
+                self.config.queue_name,
+                message.msg_id,
                 self.config.worker_id,
                 False,
                 "UNSUPPORTED_STAGE",
@@ -353,13 +389,15 @@ class ParseWorker:
                     s3_ready_result.s3_ready_job_id,
                     s3_ready_result.s3_ready_msg_id,
                 )
-                queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+                archive_current_message(conn, self.config.queue_name, message.msg_id)
         except Exception as exc:
             LOGGER.exception("parse job %s failed", claimed.job_id)
             retryable = is_parse_failure_retryable(exc)
-            fail_job_and_archive_if_dead(
+            fail_job_and_archive_current_message(
                 conn,
                 claimed.job_id,
+                self.config.queue_name,
+                message.msg_id,
                 self.config.worker_id,
                 retryable,
                 str(exc),
@@ -398,14 +436,15 @@ class S3ReadyWorker:
             self.config.worker_id,
             self.config.lock_seconds,
         )
-        if claimed is None:
-            LOGGER.info("s3_ready job %s was not claimable", message.job_id)
-            queue.archive_job_message(conn, message.job_id, self.config.worker_id)
+        if claimed is None or not claimed.claimed:
+            handle_unclaimed_message(conn, self.config.s3_ready_queue_name, message, claimed)
             return
         if claimed.stage != "s3_ready":
-            fail_job_and_archive_if_dead(
+            fail_job_and_archive_current_message(
                 conn,
                 claimed.job_id,
+                self.config.s3_ready_queue_name,
+                message.msg_id,
                 self.config.worker_id,
                 False,
                 "UNSUPPORTED_STAGE",
@@ -457,13 +496,15 @@ class S3ReadyWorker:
                 )
                 if not ok:
                     raise RuntimeError("complete_s3_ready_check returned false")
-                queue.archive_job_message(conn, claimed.job_id, self.config.worker_id)
+                archive_current_message(conn, self.config.s3_ready_queue_name, message.msg_id)
         except Exception as exc:
             LOGGER.exception("s3_ready job %s failed", claimed.job_id)
             retryable = is_s3_ready_failure_retryable(exc)
-            fail_job_and_archive_if_dead(
+            fail_job_and_archive_current_message(
                 conn,
                 claimed.job_id,
+                self.config.s3_ready_queue_name,
+                message.msg_id,
                 self.config.worker_id,
                 retryable,
                 str(exc),

--- a/tests/test_kb_parse_worker_reliability.py
+++ b/tests/test_kb_parse_worker_reliability.py
@@ -49,14 +49,33 @@ def worker_config() -> SimpleNamespace:
     )
 
 
-def claimed(stage: str) -> control_plane.ClaimedJob:
-    return control_plane.ClaimedJob(
+def claimed(stage: str) -> control_plane.ClaimJobResult:
+    return control_plane.ClaimJobResult(
+        claim_status="claimed",
+        archive_current_message=False,
         job_id="job-1",
         document_id="00000000-0000-0000-0000-000000000001",
         document_version=1,
         stage=stage,
         status="running",
         payload_json={},
+        next_retry_at=None,
+        retry_wakeup_msg_id=None,
+    )
+
+
+def claim_disposition(status: str, archive_current_message: bool) -> control_plane.ClaimJobResult:
+    return control_plane.ClaimJobResult(
+        claim_status=status,
+        archive_current_message=archive_current_message,
+        job_id="job-1",
+        document_id="00000000-0000-0000-0000-000000000001",
+        document_version=1,
+        stage="parse",
+        status="failed",
+        payload_json={},
+        next_retry_at="2026-05-11T10:00:00+00:00",
+        retry_wakeup_msg_id=42,
     )
 
 
@@ -96,16 +115,16 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
             patch("src.kb_parse_worker.worker.control_plane.claim_job", return_value=claimed("parse")),
             patch("src.kb_parse_worker.worker.load_parse_snapshot", side_effect=RuntimeError("EMPTY_RESULT")),
             patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
             ParseWorker(worker_config()).process_message(conn, message())
 
         fail_job.assert_called_once()
         self.assertFalse(fail_job.call_args.args[3])
-        archive.assert_called_once_with(conn, "job-1", "worker-1")
+        archive.assert_called_once_with(conn, "kb_parse_queue", 1)
 
-    def test_parse_timeout_marks_retryable_without_archiving_failed_job(self) -> None:
+    def test_parse_timeout_marks_retryable_and_archives_current_message(self) -> None:
         conn = object()
         fail_result = control_plane.FailJobResult(
             job_id="job-1",
@@ -120,14 +139,14 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 side_effect=JobTimeout("PARSE_JOB_TIMEOUT_AFTER_60s"),
             ),
             patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
             ParseWorker(worker_config()).process_message(conn, message())
 
         fail_job.assert_called_once()
         self.assertTrue(fail_job.call_args.args[3])
-        archive.assert_not_called()
+        archive.assert_called_once_with(conn, "kb_parse_queue", 1)
 
     def test_s3_ready_terminal_failure_marks_non_retryable_and_archives_dead_job(self) -> None:
         conn = object()
@@ -147,7 +166,7 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 return_value=SimpleNamespace(processed_manifest_local_uri=None),
             ),
             patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
             S3ReadyWorker(worker_config()).process_message(conn, message())
@@ -156,7 +175,7 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
         self.assertFalse(fail_job.call_args.args[3])
         archive.assert_called_once()
 
-    def test_s3_ready_transient_failure_marks_retryable_without_archiving_failed_job(self) -> None:
+    def test_s3_ready_transient_failure_marks_retryable_and_archives_current_message(self) -> None:
         conn = object()
         fail_result = control_plane.FailJobResult(
             job_id="job-1",
@@ -174,14 +193,40 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 side_effect=RuntimeError("S3_NOT_READY_AFTER_TIMEOUT: sync delay"),
             ),
             patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
             S3ReadyWorker(worker_config()).process_message(conn, message())
 
         fail_job.assert_called_once()
         self.assertTrue(fail_job.call_args.args[3])
+        archive.assert_called_once_with(conn, "kb_s3_ready_queue", 1)
+
+    def test_parse_backoff_not_due_leaves_current_message_when_contract_says_keep(self) -> None:
+        conn = object()
+        with (
+            patch(
+                "src.kb_parse_worker.worker.control_plane.claim_job",
+                return_value=claim_disposition("backoff_not_due", False),
+            ),
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+        ):
+            ParseWorker(worker_config()).process_message(conn, message())
+
         archive.assert_not_called()
+
+    def test_parse_backoff_not_due_archives_current_message_when_contract_says_archive(self) -> None:
+        conn = object()
+        with (
+            patch(
+                "src.kb_parse_worker.worker.control_plane.claim_job",
+                return_value=claim_disposition("backoff_not_due", True),
+            ),
+            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+        ):
+            ParseWorker(worker_config()).process_message(conn, message())
+
+        archive.assert_called_once_with(conn, "kb_parse_queue", 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch parse and S3-ready workers to typed claim dispositions and fail_job_v2 retry scheduling
- archive the current PGMQ transport message by queue/message id after terminal and retryable failure handling
- document retry wake-up behavior and cover backoff/archive cases in worker reliability tests

## Validation
- .venv/bin/python -m pytest tests/test_kb_parse_worker_reliability.py
- docpact validate-config --root . --strict
- docpact lint --root . --staged --mode enforce