### PR TITLE
fix(kb): retry final DB handoffs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-11"
-lastReviewedCommit: "0fff3e2c5fde4757d2b285f4781ae12182946b35"
+lastReviewedAt: "2026-05-15"
+lastReviewedCommit: "20c981396c87a97f3d01d190b9fd6dc3fee0aa22"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Unstructure Architecture
@@ -65,9 +65,12 @@ the referenced files still exist.
   and normalizes vectors to 1536 dimensions, stores vectors in the pickle chunks
   under `embedding`, and excludes `embedding` from the JSONL artifact.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
-  and enqueues a durable `s3_ready` job. A separate S3-ready worker then
-  verifies the processed manifest/jsonl/pkl/txt objects after NAS-to-S3 sync and
-  calls `complete_s3_ready_check(...)` to mark `processed_s3_ready`. PM2 keeps
+  and enqueues a durable `s3_ready` job. The parse worker treats that final
+  local-ready RPC plus parse-message archive as one finalization step. A
+  separate S3-ready worker then verifies the processed manifest/jsonl/pkl/txt
+  objects after NAS-to-S3 sync and calls `complete_s3_ready_check(...)` to mark
+  `processed_s3_ready`. Final DB transitions and failure writes retry transient
+  Postgres connection failures with short reconnecting backoff. PM2 keeps
   both long-running worker processes resident; each worker's heartbeat loop
   keeps its active job lock and PGMQ visibility timeout fresh. Parse and
   S3-ready jobs also enforce worker-local hard timeouts, consume typed

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Unstructure Development Runbook
@@ -168,9 +168,13 @@ The workers do not upload artifacts to S3 directly. The parse worker writes raw
 inputs and processed artifacts to NAS paths, including the manifest-declared
 JSONL, pickle, and optional full-text TXT artifacts, calls
 `complete_parse_local_ready_and_enqueue_s3_check(...)`, archives the parse queue
-message, and exits without waiting for NAS-to-S3 sync. The S3-ready worker then
-waits for the NAS sync layer to publish processed artifacts to S3 before calling
-`complete_s3_ready_check(...)`. Tune the S3-ready worker check wait window with:
+message, and exits without waiting for NAS-to-S3 sync. The local-ready RPC and
+message archive, S3-ready completion RPC and message archive, and `fail_job_v2`
+failure writes are retried up to three times for transient Postgres connection
+errors; retries reconnect before replaying the idempotent DB handoff. The
+S3-ready worker then waits for the NAS sync layer to publish processed artifacts
+to S3 before calling `complete_s3_ready_check(...)`. Tune the S3-ready worker
+check wait window with:
 
 ```text
 KB_PARSE_S3_READY_TIMEOUT_SECONDS=900

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: 0fff3e2c5fde4757d2b285f4781ae12182946b35
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+from contextlib import nullcontext
 import logging
 import threading
 import time
 from pathlib import Path
 
+import psycopg2
 import requests
 
 from . import control_plane, queue
@@ -25,6 +27,8 @@ from .snapshot import (
 )
 
 LOGGER = logging.getLogger(__name__)
+FINALIZE_DB_MAX_ATTEMPTS = 3
+FINALIZE_DB_INITIAL_BACKOFF_SECONDS = 1.0
 
 
 class JobTimeout(RuntimeError):
@@ -110,6 +114,76 @@ def archive_current_message(conn, queue_name: str, msg_id: int) -> bool:
     return queue.archive_job_message_by_id(conn, queue_name, msg_id)
 
 
+def _is_retryable_finalization_error(error: Exception) -> bool:
+    return isinstance(error, (psycopg2.InterfaceError, psycopg2.OperationalError))
+
+
+def _finalization_backoff_seconds(attempt: int) -> float:
+    return FINALIZE_DB_INITIAL_BACKOFF_SECONDS * (2 ** max(0, attempt - 1))
+
+
+def complete_parse_local_ready_and_archive_with_retry(
+    config: WorkerConfig,
+    conn,
+    job_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_local_uri: str,
+    artifact_uuid: str,
+    manifest_hash: str,
+    chunk_count: int,
+    metadata_json: dict,
+    s3_ready_payload_json: dict,
+    queue_name: str,
+    msg_id: int,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
+) -> control_plane.S3ReadyEnqueueResult:
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        connection_context = (
+            nullcontext(conn)
+            if attempt == 1
+            else control_plane.connect(config.database_url)
+        )
+        try:
+            with connection_context as active_conn:
+                result = control_plane.complete_parse_local_ready_and_enqueue_s3_check(
+                    active_conn,
+                    job_id,
+                    config.worker_id,
+                    document_id,
+                    document_version,
+                    manifest_local_uri,
+                    artifact_uuid,
+                    manifest_hash,
+                    chunk_count,
+                    metadata_json,
+                    s3_ready_payload_json,
+                )
+                if result is None:
+                    raise RuntimeError(
+                        "complete_parse_local_ready_and_enqueue_s3_check returned no row"
+                    )
+                archive_current_message(active_conn, queue_name, msg_id)
+                return result
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "parse job %s finalization DB write failed on attempt %s/%s; "
+                "reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("parse finalization retry loop exhausted")
+
+
 def handle_unclaimed_message(
     conn,
     queue_name: str,
@@ -132,6 +206,7 @@ def handle_unclaimed_message(
 
 
 def fail_job_and_archive_current_message(
+    config: WorkerConfig,
     conn,
     job_id: str,
     queue_name: str,
@@ -140,19 +215,109 @@ def fail_job_and_archive_current_message(
     retryable: bool,
     error: str,
     error_stage: str,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
 ) -> control_plane.FailJobResult | None:
-    result = control_plane.fail_job(conn, job_id, worker_id, retryable, error, error_stage)
-    if result is not None:
-        LOGGER.info(
-            "job %s failed status=%s retryable=%s next_retry_at=%s retry_wakeup_msg_id=%s",
-            job_id,
-            result.job_status,
-            retryable,
-            result.next_retry_at,
-            result.retry_wakeup_msg_id,
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        connection_context = (
+            nullcontext(conn)
+            if attempt == 1
+            else control_plane.connect(config.database_url)
         )
-        archive_current_message(conn, queue_name, msg_id)
-    return result
+        try:
+            with connection_context as active_conn:
+                result = control_plane.fail_job(
+                    active_conn,
+                    job_id,
+                    worker_id,
+                    retryable,
+                    error,
+                    error_stage,
+                )
+                if result is not None:
+                    LOGGER.info(
+                        "job %s failed status=%s retryable=%s next_retry_at=%s retry_wakeup_msg_id=%s",
+                        job_id,
+                        result.job_status,
+                        retryable,
+                        result.next_retry_at,
+                        result.retry_wakeup_msg_id,
+                    )
+                    archive_current_message(active_conn, queue_name, msg_id)
+                return result
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "job %s fail_job DB write failed on attempt %s/%s; reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("fail_job retry loop exhausted")
+
+
+def complete_s3_ready_check_and_archive_with_retry(
+    config: WorkerConfig,
+    conn,
+    job_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_s3_key: str,
+    manifest_hash: str,
+    artifact_uuid: str,
+    manifest_local_uri: str,
+    chunk_count: int,
+    queue_name: str,
+    msg_id: int,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
+) -> bool:
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        connection_context = (
+            nullcontext(conn)
+            if attempt == 1
+            else control_plane.connect(config.database_url)
+        )
+        try:
+            with connection_context as active_conn:
+                ok = control_plane.complete_s3_ready_check(
+                    active_conn,
+                    job_id,
+                    config.worker_id,
+                    document_id,
+                    document_version,
+                    manifest_s3_key,
+                    manifest_hash,
+                    artifact_uuid,
+                    manifest_local_uri,
+                    chunk_count,
+                )
+                if not ok:
+                    raise RuntimeError("complete_s3_ready_check returned false")
+                archive_current_message(active_conn, queue_name, msg_id)
+                return True
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "s3_ready job %s finalization DB write failed on attempt %s/%s; "
+                "reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("s3_ready finalization retry loop exhausted")
 
 
 def _sha256(path: Path) -> str:
@@ -251,6 +416,7 @@ class ParseWorker:
             return
         if claimed.stage != "parse":
             fail_job_and_archive_current_message(
+                self.config,
                 conn,
                 claimed.job_id,
                 self.config.queue_name,
@@ -368,10 +534,10 @@ class ParseWorker:
                     "s3_bucket": self.config.s3_bucket,
                     "s3_prefix": self.config.s3_processed_prefix,
                 }
-                s3_ready_result = control_plane.complete_parse_local_ready_and_enqueue_s3_check(
+                s3_ready_result = complete_parse_local_ready_and_archive_with_retry(
+                    self.config,
                     conn,
                     claimed.job_id,
-                    self.config.worker_id,
                     claimed.document_id,
                     claimed.document_version,
                     manifest_local_uri,
@@ -380,20 +546,20 @@ class ParseWorker:
                     artifact_info.chunk_count,
                     metadata_json,
                     s3_ready_payload_json,
+                    self.config.queue_name,
+                    message.msg_id,
                 )
-                if s3_ready_result is None:
-                    raise RuntimeError("complete_parse_local_ready_and_enqueue_s3_check returned no row")
                 LOGGER.info(
                     "parse job %s completed local artifacts and queued s3_ready job %s msg %s",
                     claimed.job_id,
                     s3_ready_result.s3_ready_job_id,
                     s3_ready_result.s3_ready_msg_id,
                 )
-                archive_current_message(conn, self.config.queue_name, message.msg_id)
         except Exception as exc:
             LOGGER.exception("parse job %s failed", claimed.job_id)
             retryable = is_parse_failure_retryable(exc)
             fail_job_and_archive_current_message(
+                self.config,
                 conn,
                 claimed.job_id,
                 self.config.queue_name,
@@ -441,6 +607,7 @@ class S3ReadyWorker:
             return
         if claimed.stage != "s3_ready":
             fail_job_and_archive_current_message(
+                self.config,
                 conn,
                 claimed.job_id,
                 self.config.s3_ready_queue_name,
@@ -482,10 +649,10 @@ class S3ReadyWorker:
                 lease.check()
                 deadline.check()
 
-                ok = control_plane.complete_s3_ready_check(
+                ok = complete_s3_ready_check_and_archive_with_retry(
+                    self.config,
                     conn,
                     claimed.job_id,
-                    self.config.worker_id,
                     claimed.document_id,
                     claimed.document_version,
                     manifest_s3_key,
@@ -493,14 +660,16 @@ class S3ReadyWorker:
                     artifact_info.artifact_uuid,
                     manifest_path.as_posix(),
                     artifact_info.chunk_count,
+                    self.config.s3_ready_queue_name,
+                    message.msg_id,
                 )
                 if not ok:
                     raise RuntimeError("complete_s3_ready_check returned false")
-                archive_current_message(conn, self.config.s3_ready_queue_name, message.msg_id)
         except Exception as exc:
             LOGGER.exception("s3_ready job %s failed", claimed.job_id)
             retryable = is_s3_ready_failure_retryable(exc)
             fail_job_and_archive_current_message(
+                self.config,
                 conn,
                 claimed.job_id,
                 self.config.s3_ready_queue_name,

--- a/tests/test_kb_parse_worker_reliability.py
+++ b/tests/test_kb_parse_worker_reliability.py
@@ -4,11 +4,16 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import psycopg2
+
 from src.kb_parse_worker import control_plane, queue
 from src.kb_parse_worker.worker import (
     JobTimeout,
     ParseWorker,
     S3ReadyWorker,
+    complete_s3_ready_check_and_archive_with_retry,
+    complete_parse_local_ready_and_archive_with_retry,
+    fail_job_and_archive_current_message,
     is_parse_failure_retryable,
     is_s3_ready_failure_retryable,
 )
@@ -81,6 +86,17 @@ def claim_disposition(status: str, archive_current_message: bool) -> control_pla
 
 def message() -> queue.QueueMessage:
     return queue.QueueMessage(msg_id=1, job_id="job-1", raw_payload={"job_id": "job-1"})
+
+
+class FakeConnection:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __enter__(self) -> "FakeConnection":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        return None
 
 
 class KbParseWorkerReliabilityTests(unittest.TestCase):
@@ -227,6 +243,177 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
             ParseWorker(worker_config()).process_message(conn, message())
 
         archive.assert_called_once_with(conn, "kb_parse_queue", 1)
+
+    def test_parse_finalization_reconnects_and_retries_db_connection_errors(self) -> None:
+        original_conn = FakeConnection("original")
+        retry_conn = FakeConnection("retry")
+        result = control_plane.S3ReadyEnqueueResult(
+            parse_job_id="job-1",
+            parse_job_status="succeeded",
+            s3_ready_job_id="s3-job-1",
+            s3_ready_msg_id=123,
+            document_status="s3_sync_pending",
+        )
+        calls: list[FakeConnection] = []
+
+        def complete(conn, *_args, **_kwargs):
+            calls.append(conn)
+            if len(calls) == 1:
+                raise psycopg2.OperationalError("server closed the connection unexpectedly")
+            return result
+
+        with (
+            patch(
+                "src.kb_parse_worker.worker.control_plane.complete_parse_local_ready_and_enqueue_s3_check",
+                side_effect=complete,
+            ),
+            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.time.sleep") as sleep,
+            patch("src.kb_parse_worker.worker.LOGGER.warning"),
+        ):
+            actual = complete_parse_local_ready_and_archive_with_retry(
+                worker_config(),
+                original_conn,
+                "job-1",
+                "00000000-0000-0000-0000-000000000001",
+                1,
+                "/processed/manifest.json",
+                "00000000-0000-0000-0000-000000000002",
+                "hash",
+                7,
+                {"processed": {}},
+                {"manifest_s3_key": "processed/manifest.json"},
+                "kb_parse_queue",
+                1,
+            )
+
+        self.assertEqual(actual, result)
+        self.assertEqual(calls, [original_conn, retry_conn])
+        connect.assert_called_once_with("postgresql://test")
+        sleep.assert_called_once_with(1.0)
+        archive.assert_called_once_with(retry_conn, "kb_parse_queue", 1)
+
+    def test_parse_finalization_does_not_retry_non_db_errors(self) -> None:
+        original_conn = FakeConnection("original")
+
+        with (
+            patch(
+                "src.kb_parse_worker.worker.control_plane.complete_parse_local_ready_and_enqueue_s3_check",
+                side_effect=RuntimeError(
+                    "complete_parse_local_ready_and_enqueue_s3_check returned no row"
+                ),
+            ) as complete,
+            patch("src.kb_parse_worker.worker.control_plane.connect") as connect,
+            patch("src.kb_parse_worker.worker.archive_current_message") as archive,
+            patch("src.kb_parse_worker.worker.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "returned no row"):
+                complete_parse_local_ready_and_archive_with_retry(
+                    worker_config(),
+                    original_conn,
+                    "job-1",
+                    "00000000-0000-0000-0000-000000000001",
+                    1,
+                    "/processed/manifest.json",
+                    "00000000-0000-0000-0000-000000000002",
+                    "hash",
+                    7,
+                    {"processed": {}},
+                    {"manifest_s3_key": "processed/manifest.json"},
+                    "kb_parse_queue",
+                    1,
+                )
+
+        complete.assert_called_once()
+        connect.assert_not_called()
+        archive.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_s3_ready_finalization_reconnects_and_retries_db_connection_errors(self) -> None:
+        original_conn = FakeConnection("original")
+        retry_conn = FakeConnection("retry")
+        calls: list[FakeConnection] = []
+
+        def complete(conn, *_args, **_kwargs):
+            calls.append(conn)
+            if len(calls) == 1:
+                raise psycopg2.InterfaceError("connection already closed")
+            return True
+
+        with (
+            patch(
+                "src.kb_parse_worker.worker.control_plane.complete_s3_ready_check",
+                side_effect=complete,
+            ),
+            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.time.sleep") as sleep,
+            patch("src.kb_parse_worker.worker.LOGGER.warning"),
+        ):
+            ok = complete_s3_ready_check_and_archive_with_retry(
+                worker_config(),
+                original_conn,
+                "job-1",
+                "00000000-0000-0000-0000-000000000001",
+                1,
+                "processed/manifest.json",
+                "hash",
+                "00000000-0000-0000-0000-000000000002",
+                "/processed/manifest.json",
+                7,
+                "kb_s3_ready_queue",
+                1,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(calls, [original_conn, retry_conn])
+        connect.assert_called_once_with("postgresql://test")
+        sleep.assert_called_once_with(1.0)
+        archive.assert_called_once_with(retry_conn, "kb_s3_ready_queue", 1)
+
+    def test_fail_job_reconnects_and_retries_db_connection_errors(self) -> None:
+        original_conn = FakeConnection("original")
+        retry_conn = FakeConnection("retry")
+        result = control_plane.FailJobResult(
+            job_id="job-1",
+            job_status="failed",
+            document_status="parse_queued",
+            next_retry_at="2026-05-15T10:00:00+00:00",
+            retry_wakeup_msg_id=10,
+        )
+        calls: list[FakeConnection] = []
+
+        def fail(conn, *_args, **_kwargs):
+            calls.append(conn)
+            if len(calls) == 1:
+                raise psycopg2.OperationalError("server closed the connection unexpectedly")
+            return result
+
+        with (
+            patch("src.kb_parse_worker.worker.control_plane.fail_job", side_effect=fail),
+            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.time.sleep") as sleep,
+            patch("src.kb_parse_worker.worker.LOGGER.warning"),
+        ):
+            actual = fail_job_and_archive_current_message(
+                worker_config(),
+                original_conn,
+                "job-1",
+                "kb_parse_queue",
+                1,
+                "worker-1",
+                True,
+                "temporary failure",
+                "parse",
+            )
+
+        self.assertEqual(actual, result)
+        self.assertEqual(calls, [original_conn, retry_conn])
+        connect.assert_called_once_with("postgresql://test")
+        sleep.assert_called_once_with(1.0)
+        archive.assert_called_once_with(retry_conn, "kb_parse_queue", 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry parse and S3-ready final DB handoffs with reconnecting backoff
- retry fail_job_v2 writes on transient Postgres connection drops
- document finalization retry semantics and add reliability tests

## Validation
- python -m unittest discover -s tests -p 'test_*.py'
- python -m compileall src/kb_parse_worker
- docpact lint --root . --files .docpact/config.yaml,AGENTS.md,README.md,_docs/README.md,_docs/architecture/repo-architecture.md,_docs/contracts/repo-contract.md,_docs/runbooks/development.md,_docs/standards/documentation-standards.md,src/journals/AGENTS.md,src/kb_parse_worker/worker.py,tests/test_kb_parse_worker_reliability.py --format json