### PR TITLE
fix(kb): add parse finalization reconciler

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-15"
-lastReviewedCommit: "20c981396c87a97f3d01d190b9fd6dc3fee0aa22"
+lastReviewedAt: "2026-05-16"
+lastReviewedCommit: "16836b132b4eb369a474bb570262cfb0a093addc"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Unstructure Architecture

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -66,7 +66,11 @@ the referenced files still exist.
   under `embedding`, and excludes `embedding` from the JSONL artifact.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
   and enqueues a durable `s3_ready` job. The parse worker treats that final
-  local-ready RPC plus parse-message archive as one finalization step. A
+  local-ready RPC plus parse-message archive as one finalization step. A parse
+  finalization reconciler can repair historical splits where deterministic
+  processed artifacts already exist on NAS but the final DB handoff did not
+  commit; it validates the local manifest identity and replays the local-ready
+  DB transition without re-running document parsing. A
   separate S3-ready worker then verifies the processed manifest/jsonl/pkl/txt
   objects after NAS-to-S3 sync and calls `complete_s3_ready_check(...)` to mark
   `processed_s3_ready`. Final DB transitions and failure writes retry transient

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Unstructure Development Runbook

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -52,6 +52,8 @@ Run one queue message:
 ```bash
 python -m src.kb_parse_worker.cli once
 python -m src.kb_parse_worker.cli once --worker s3-ready
+python -m src.kb_parse_worker.cli once --worker parse-finalization-reconciler --dry-run
+python -m src.kb_parse_worker.cli once --worker parse-finalization-reconciler
 ```
 
 Run continuously:
@@ -59,6 +61,7 @@ Run continuously:
 ```bash
 python -m src.kb_parse_worker.cli run
 python -m src.kb_parse_worker.cli run --worker s3-ready
+python -m src.kb_parse_worker.cli run --worker parse-finalization-reconciler
 ```
 
 Run continuously under PM2:
@@ -186,6 +189,15 @@ For deployments where NAS-to-S3 sync can take a long time, keep the parse worker
 and S3-ready worker as separate PM2 processes. Retry attempts for the S3-ready
 stage reuse `processed_manifest_local_uri` and only re-check processed S3
 readiness; they do not parse the document again.
+
+If a parse job generated deterministic processed artifacts but the final DB
+handoff never committed, run the parse finalization reconciler on the worker
+host. It scans stale `failed`, `dead`, or expired `running` parse jobs whose
+documents do not yet have processed manifest fields, checks the deterministic
+`NAS_PROCESSED_ROOT/{processed_storage_path}/{document_id}/manifest.json`, and
+calls `replay_parse_local_ready_from_artifact(...)` to mark local processed
+artifacts ready and enqueue `s3_ready`. Use `--dry-run` before live replay, and
+use `--document-id <uuid>` to limit a repair to one document.
 
 Worker failures are classified before calling `fail_job_v2(...)`. Terminal parse
 failures such as `RAW_HASH_MISMATCH`, `RAW_STORAGE_PATH_MISMATCH`, malformed

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 20c981396c87a97f3d01d190b9fd6dc3fee0aa22
+lastReviewedAt: 2026-05-16
+lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/cli.py
+++ b/src/kb_parse_worker/cli.py
@@ -6,17 +6,34 @@ import argparse
 import logging
 
 from .config import WorkerConfig
+from .reconciler import ParseFinalizationReconciler
 from .worker import ParseWorker, S3ReadyWorker
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run KB parse or S3-ready workers.")
+    parser = argparse.ArgumentParser(description="Run KB parse pipeline workers.")
     parser.add_argument("mode", choices=("once", "run"), help="Run one queue message or poll forever.")
     parser.add_argument(
         "--worker",
-        choices=("parse", "s3-ready"),
+        choices=("parse", "s3-ready", "parse-finalization-reconciler"),
         default="parse",
         help="Worker role to run.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Maximum candidates per reconciler scan.",
+    )
+    parser.add_argument(
+        "--document-id",
+        default=None,
+        help="Restrict the parse finalization reconciler to one document id.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="For the parse finalization reconciler, report replayable jobs without writing DB state.",
     )
     parser.add_argument("--log-level", default="INFO", help="Python logging level.")
     args = parser.parse_args()
@@ -26,7 +43,17 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
     config = WorkerConfig.from_env()
-    worker = ParseWorker(config) if args.worker == "parse" else S3ReadyWorker(config)
+    if args.worker == "parse":
+        worker = ParseWorker(config)
+    elif args.worker == "s3-ready":
+        worker = S3ReadyWorker(config)
+    else:
+        worker = ParseFinalizationReconciler(
+            config,
+            limit=args.limit,
+            document_id=args.document_id,
+            dry_run=args.dry_run,
+        )
     if args.mode == "once":
         worker.run_once()
     else:

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -258,6 +258,55 @@ def complete_parse_local_ready_and_enqueue_s3_check(
     )
 
 
+def replay_parse_local_ready_from_artifact(
+    conn,
+    job_id: str,
+    worker_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_local_uri: str,
+    artifact_uuid: str,
+    manifest_hash: str,
+    chunk_count: int,
+    metadata_json: dict,
+    s3_ready_payload_json: dict,
+    replay_reason: str,
+) -> S3ReadyEnqueueResult | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select *
+            from public.replay_parse_local_ready_from_artifact(
+              %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                worker_id,
+                document_id,
+                document_version,
+                manifest_local_uri,
+                artifact_uuid,
+                manifest_hash,
+                chunk_count,
+                psycopg2.extras.Json(metadata_json),
+                psycopg2.extras.Json(s3_ready_payload_json),
+                replay_reason,
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    return S3ReadyEnqueueResult(
+        parse_job_id=str(row["parse_job_id"]),
+        parse_job_status=str(row["parse_job_status"]),
+        s3_ready_job_id=str(row["s3_ready_job_id"]),
+        s3_ready_msg_id=int(row["s3_ready_msg_id"]),
+        document_status=str(row["document_status"]),
+    )
+
+
 def complete_s3_ready_check(
     conn,
     job_id: str,

--- a/src/kb_parse_worker/reconciler.py
+++ b/src/kb_parse_worker/reconciler.py
@@ -1,0 +1,275 @@
+"""Replay parse finalization from deterministic processed artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg2.extras
+
+from . import control_plane, queue
+from .config import WorkerConfig
+from .manifest import ArtifactInfo, load_artifact_info
+from .snapshot import collection_storage_path, processed_storage_path
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ParseFinalizationCandidate:
+    job_id: str
+    document_id: str
+    document_version: int
+    job_status: str
+    document_status: str
+    collection_path: str
+    collection_storage_path: str
+    processed_storage_path: str
+    pgmq_queue: str | None
+    pgmq_msg_id: int | None
+    updated_at: str | None
+
+
+def canonical_manifest_hash(manifest: dict) -> str:
+    manifest_bytes = json.dumps(manifest, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(manifest_bytes).hexdigest()
+
+
+def list_parse_finalization_candidates(
+    conn,
+    limit: int,
+    document_id: str | None = None,
+) -> list[ParseFinalizationCandidate]:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    filters = [
+        "j.stage = 'parse'::public.kb_job_stage",
+        "j.document_version = d.document_version",
+        "d.deleted_at is null",
+        "d.processed_manifest_local_uri is null",
+        "d.processed_artifact_uuid is null",
+        """(
+          j.status in ('failed'::public.kb_job_status, 'dead'::public.kb_job_status)
+          or (
+            j.status = 'running'::public.kb_job_status
+            and (j.locked_until is null or j.locked_until < now())
+          )
+        )""",
+    ]
+    params: list[object] = []
+    if document_id is not None:
+        filters.append("d.id = %s")
+        params.append(document_id)
+    params.append(limit)
+
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            f"""
+            select
+              j.id as job_id,
+              j.document_id,
+              j.document_version,
+              j.status as job_status,
+              j.pgmq_queue,
+              j.pgmq_msg_id,
+              j.updated_at,
+              d.status as document_status,
+              c.path as collection_path
+            from public.kb_jobs j
+            join public.kb_documents d on d.id = j.document_id
+            join public.kb_collections c on c.id = d.primary_collection_id
+            where {" and ".join(filters)}
+            order by j.updated_at asc, j.created_at asc
+            limit %s
+            """,
+            params,
+        )
+        rows = cur.fetchall()
+    conn.commit()
+
+    candidates: list[ParseFinalizationCandidate] = []
+    for row in rows:
+        storage_path = collection_storage_path(str(row["collection_path"]))
+        candidates.append(
+            ParseFinalizationCandidate(
+                job_id=str(row["job_id"]),
+                document_id=str(row["document_id"]),
+                document_version=int(row["document_version"]),
+                job_status=str(row["job_status"]),
+                document_status=str(row["document_status"]),
+                collection_path=str(row["collection_path"]),
+                collection_storage_path=storage_path,
+                processed_storage_path=processed_storage_path(storage_path),
+                pgmq_queue=str(row["pgmq_queue"]) if row["pgmq_queue"] else None,
+                pgmq_msg_id=int(row["pgmq_msg_id"]) if row["pgmq_msg_id"] is not None else None,
+                updated_at=row["updated_at"].isoformat() if row["updated_at"] is not None else None,
+            )
+        )
+    return candidates
+
+
+def manifest_path_for_candidate(config: WorkerConfig, candidate: ParseFinalizationCandidate) -> Path:
+    return (
+        config.nas_processed_root
+        / candidate.processed_storage_path
+        / candidate.document_id
+        / "manifest.json"
+    )
+
+
+def processed_manifest_s3_key(config: WorkerConfig, candidate: ParseFinalizationCandidate) -> str:
+    clean_prefix = config.s3_processed_prefix.strip("/")
+    return f"{clean_prefix}/{candidate.processed_storage_path}/{candidate.document_id}/manifest.json"
+
+
+def validate_manifest(candidate: ParseFinalizationCandidate, artifact_info: ArtifactInfo) -> None:
+    manifest = artifact_info.manifest
+    expected = {
+        "document_id": candidate.document_id,
+        "document_version": candidate.document_version,
+        "collection_path": candidate.collection_path,
+        "collection_storage_path": candidate.collection_storage_path,
+        "processed_storage_path": candidate.processed_storage_path,
+    }
+    for key, value in expected.items():
+        if manifest.get(key) != value:
+            raise RuntimeError(f"MANIFEST_MISMATCH: {key}")
+
+
+def validate_local_artifact_files(manifest_path: Path, artifact_info: ArtifactInfo) -> None:
+    manifest = artifact_info.manifest
+    base_dir = manifest_path.parent
+    for artifact_key, artifact_name in manifest["artifacts"].items():
+        artifact_path = base_dir / str(artifact_name)
+        if not artifact_path.exists():
+            raise RuntimeError(f"LOCAL_ARTIFACT_MISSING: {artifact_name}")
+        expected_size = int(manifest["size_bytes"][artifact_key])
+        if artifact_path.stat().st_size != expected_size:
+            raise RuntimeError(f"LOCAL_ARTIFACT_SIZE_MISMATCH: {artifact_name}")
+
+
+def metadata_from_manifest(config: WorkerConfig, artifact_info: ArtifactInfo) -> dict:
+    manifest = artifact_info.manifest
+    processed = {
+        "parser_profile": manifest.get("parser_profile", config.parser_profile),
+        "parser_version": manifest.get("parser_version", config.parser_version),
+        "chunk_count": artifact_info.chunk_count,
+        "artifact_uuid": artifact_info.artifact_uuid,
+    }
+    if manifest.get("embedding") is not None:
+        processed["embedding"] = manifest["embedding"]
+    return {"processed": processed}
+
+
+def s3_ready_payload_for_candidate(
+    config: WorkerConfig,
+    candidate: ParseFinalizationCandidate,
+) -> dict:
+    return {
+        "collection_path": candidate.collection_path,
+        "collection_storage_path": candidate.collection_storage_path,
+        "processed_storage_path": candidate.processed_storage_path,
+        "manifest_s3_key": processed_manifest_s3_key(config, candidate),
+        "s3_bucket": config.s3_bucket,
+        "s3_prefix": config.s3_processed_prefix,
+        "trigger": "parse_finalization_replay",
+    }
+
+
+class ParseFinalizationReconciler:
+    def __init__(
+        self,
+        config: WorkerConfig,
+        limit: int = 25,
+        document_id: str | None = None,
+        dry_run: bool = False,
+    ):
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        self.config = config
+        self.limit = limit
+        self.document_id = document_id
+        self.dry_run = dry_run
+
+    def run_forever(self) -> None:
+        while True:
+            reconciled = self.run_once()
+            if not reconciled:
+                time.sleep(self.config.poll_interval_seconds)
+
+    def run_once(self) -> int:
+        with control_plane.connect(self.config.database_url) as conn:
+            candidates = list_parse_finalization_candidates(conn, self.limit, self.document_id)
+            reconciled = 0
+            for candidate in candidates:
+                if self.reconcile_candidate(conn, candidate):
+                    reconciled += 1
+            return reconciled
+
+    def reconcile_candidate(self, conn, candidate: ParseFinalizationCandidate) -> bool:
+        manifest_path = manifest_path_for_candidate(self.config, candidate)
+        if not manifest_path.exists():
+            LOGGER.info(
+                "parse finalization candidate job=%s document=%s has no manifest at %s",
+                candidate.job_id,
+                candidate.document_id,
+                manifest_path,
+            )
+            return False
+
+        artifact_info = load_artifact_info(manifest_path)
+        validate_manifest(candidate, artifact_info)
+        validate_local_artifact_files(manifest_path, artifact_info)
+        manifest_hash = canonical_manifest_hash(artifact_info.manifest)
+        metadata_json = metadata_from_manifest(self.config, artifact_info)
+        s3_ready_payload_json = s3_ready_payload_for_candidate(self.config, candidate)
+
+        if self.dry_run:
+            LOGGER.info(
+                "parse finalization candidate job=%s document=%s is replayable from %s",
+                candidate.job_id,
+                candidate.document_id,
+                manifest_path,
+            )
+            return True
+
+        result = control_plane.replay_parse_local_ready_from_artifact(
+            conn,
+            candidate.job_id,
+            self.config.worker_id,
+            candidate.document_id,
+            candidate.document_version,
+            manifest_path.as_posix(),
+            artifact_info.artifact_uuid,
+            manifest_hash,
+            artifact_info.chunk_count,
+            metadata_json,
+            s3_ready_payload_json,
+            "processed_manifest_found_by_reconciler",
+        )
+        if result is None:
+            LOGGER.warning(
+                "parse finalization replay returned no row for job=%s document=%s status=%s document_status=%s",
+                candidate.job_id,
+                candidate.document_id,
+                candidate.job_status,
+                candidate.document_status,
+            )
+            return False
+
+        if candidate.pgmq_queue and candidate.pgmq_msg_id is not None:
+            queue.archive_job_message_by_id(conn, candidate.pgmq_queue, candidate.pgmq_msg_id)
+
+        LOGGER.info(
+            "replayed parse finalization job=%s document=%s s3_ready_job=%s msg=%s",
+            candidate.job_id,
+            candidate.document_id,
+            result.s3_ready_job_id,
+            result.s3_ready_msg_id,
+        )
+        return True

--- a/tests/test_kb_parse_worker_reconciler.py
+++ b/tests/test_kb_parse_worker_reconciler.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.kb_parse_worker import control_plane
+from src.kb_parse_worker.reconciler import (
+    ParseFinalizationCandidate,
+    ParseFinalizationReconciler,
+    canonical_manifest_hash,
+    manifest_path_for_candidate,
+    processed_manifest_s3_key,
+)
+
+
+def config(processed_root: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        database_url="postgresql://test",
+        worker_id="worker-1",
+        poll_interval_seconds=1,
+        nas_processed_root=processed_root,
+        parser_profile="mineru_with_images",
+        parser_version="unstructure-serve",
+        s3_bucket="tiangong",
+        s3_processed_prefix="processed_docs",
+    )
+
+
+def candidate() -> ParseFinalizationCandidate:
+    return ParseFinalizationCandidate(
+        job_id="11111111-1111-1111-1111-111111111111",
+        document_id="22222222-2222-2222-2222-222222222222",
+        document_version=3,
+        job_status="dead",
+        document_status="failed",
+        collection_path="/course/thu_humanities",
+        collection_storage_path="course/thu_humanities",
+        processed_storage_path="course_pickle/thu_humanities_pickle",
+        pgmq_queue="kb_parse_queue",
+        pgmq_msg_id=404,
+        updated_at=None,
+    )
+
+
+def write_manifest(root: Path, item: ParseFinalizationCandidate) -> dict:
+    manifest = {
+        "document_id": item.document_id,
+        "document_version": item.document_version,
+        "artifact_uuid": "33333333-3333-3333-3333-333333333333",
+        "collection_id": "44444444-4444-4444-4444-444444444444",
+        "collection_path": item.collection_path,
+        "collection_storage_path": item.collection_storage_path,
+        "processed_storage_path": item.processed_storage_path,
+        "chunk_count": 12,
+        "artifacts": {
+            "chunks_jsonl": "33333333-3333-3333-3333-333333333333.jsonl",
+            "chunks_pkl": "33333333-3333-3333-3333-333333333333.pkl",
+        },
+        "sha256": {
+            "chunks_jsonl": "a" * 64,
+            "chunks_pkl": "b" * 64,
+        },
+        "size_bytes": {
+            "chunks_jsonl": 10,
+            "chunks_pkl": 20,
+        },
+        "parser_profile": "mineru_with_images",
+        "parser_version": "unstructure-serve",
+        "embedding": {"model": "Qwen/Qwen3-Embedding-8B", "dimensions": 1536},
+    }
+    path = manifest_path_for_candidate(config(root), item)
+    path.parent.mkdir(parents=True)
+    path.parent.joinpath(manifest["artifacts"]["chunks_jsonl"]).write_text("x" * 10, encoding="utf-8")
+    path.parent.joinpath(manifest["artifacts"]["chunks_pkl"]).write_bytes(b"x" * 20)
+    path.write_text(json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2), encoding="utf-8")
+    return manifest
+
+
+class ParseFinalizationReconcilerTests(unittest.TestCase):
+    def test_canonical_manifest_hash_matches_worker_manifest_hash(self) -> None:
+        manifest = {"b": 2, "a": "清华"}
+        expected = hashlib.sha256(
+            json.dumps(manifest, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(canonical_manifest_hash(manifest), expected)
+
+    def test_replays_existing_manifest_and_archives_stale_parse_message(self) -> None:
+        item = candidate()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = write_manifest(Path(tmp_dir), item)
+            worker = ParseFinalizationReconciler(config(Path(tmp_dir)), limit=1)
+            replay_result = control_plane.S3ReadyEnqueueResult(
+                parse_job_id=item.job_id,
+                parse_job_status="succeeded",
+                s3_ready_job_id="55555555-5555-5555-5555-555555555555",
+                s3_ready_msg_id=99,
+                document_status="s3_sync_pending",
+            )
+            with (
+                patch(
+                    "src.kb_parse_worker.reconciler.control_plane.replay_parse_local_ready_from_artifact",
+                    return_value=replay_result,
+                ) as replay,
+                patch(
+                    "src.kb_parse_worker.reconciler.queue.archive_job_message_by_id",
+                    return_value=True,
+                ) as archive,
+            ):
+                conn = object()
+                self.assertTrue(worker.reconcile_candidate(conn, item))
+
+            replay.assert_called_once()
+            call_args = replay.call_args.args
+            self.assertEqual(call_args[1], item.job_id)
+            self.assertEqual(call_args[3], item.document_id)
+            self.assertEqual(call_args[6], manifest["artifact_uuid"])
+            self.assertEqual(call_args[10]["manifest_s3_key"], processed_manifest_s3_key(worker.config, item))
+            self.assertEqual(call_args[9]["processed"]["embedding"], manifest["embedding"])
+            archive.assert_called_once_with(conn, item.pgmq_queue, item.pgmq_msg_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a parse finalization reconciler that replays DB local-ready finalization from deterministic NAS processed artifacts
- add a control-plane wrapper for replay_parse_local_ready_from_artifact and CLI worker mode with dry-run/document filters
- document the repair workflow and worker topology

## Validation
- .venv/bin/python -m unittest tests.test_kb_parse_worker_reconciler tests.test_kb_parse_worker_reliability
- .venv/bin/python -m compileall src/kb_parse_worker
- docpact validate-config --root . --strict