### PR TITLE
Add two-stage KB parse worker support

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-16"
-lastReviewedCommit: "16836b132b4eb369a474bb570262cfb0a093addc"
+lastReviewedAt: "2026-05-17"
+lastReviewedCommit: "1a689ec9260599e88a35283e614364c82de5e44f"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Unstructure Architecture
@@ -29,9 +29,12 @@ Workflows are organized by source domain under `src/**`.
   source-domain processing scripts.
 - `src/kb_parse_worker/**`: KB F03 parse and S3-ready workers. The parse
   worker consumes `kb_parse_queue`, claims jobs through the KB control plane,
-  calls Unstructure-Serve, publishes processed artifacts to NAS, and enqueues
-  the S3-ready check. The S3-ready worker consumes `kb_s3_ready_queue` and
-  marks processed artifacts ready after S3 verification.
+  calls Unstructure-Serve either through the legacy synchronous
+  `/mineru_with_images` endpoint or, when `KB_PARSE_USE_TWO_STAGE=true`,
+  submits `/two_stage/task` and polls `/two_stage/task/{task_id}` for the same
+  `result`/`txt` payload contract. It publishes processed artifacts to NAS and
+  enqueues the S3-ready check. The S3-ready worker consumes
+  `kb_s3_ready_queue` and marks processed artifacts ready after S3 verification.
 - `ecosystem.kb_parse_worker.json`: PM2 process definitions for the KB parse
   worker and S3-ready worker.
 - `src/journals/**`: journal workflows; also read `src/journals/AGENTS.md`.
@@ -57,13 +60,16 @@ the referenced files still exist.
   `jsonl`/`pkl`/`txt`/`manifest.json` artifacts under the configured NAS
   processed root using a `_pickle` suffixed path derived from the collection
   storage path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
-  The worker requests `return_txt=true` from Unstructure-Serve, drops parser
-  chunks whose `text` is empty before embedding, and writes the returned
-  whole-document text as `{artifact_uuid}.txt` beside the pickle artifact.
-  Before artifact writes, the worker embeds every remaining chunk `text` field
-  through the OpenAI-compatible Qwen3-Embedding-8B endpoint, locally truncates
-  and normalizes vectors to 1536 dimensions, stores vectors in the pickle chunks
-  under `embedding`, and excludes `embedding` from the JSONL artifact.
+  The worker requests `return_txt=true` from Unstructure-Serve in both sync and
+  two-stage modes, drops parser chunks whose `text` is empty before embedding,
+  and writes the returned whole-document text as `{artifact_uuid}.txt` beside
+  the pickle artifact.
+  Before artifact writes, the worker stores the parser result as a JSON artifact,
+  splits chunks above the embedding token cap into child chunks, embeds every
+  child chunk `text` field through the OpenAI-compatible Qwen3-Embedding-8B
+  endpoint, locally truncates and normalizes vectors to 1536 dimensions, stores
+  vectors in the pickle chunks under `embedding`, and excludes `embedding` from
+  the JSONL artifact.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
   and enqueues a durable `s3_ready` job. The parse worker treats that final
   local-ready RPC plus parse-message archive as one finalization step. A parse

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Unstructure Development Runbook
@@ -123,18 +123,41 @@ Current workspace worker deployment points `UNSTRUCTURE_SERVE_URL` at:
 UNSTRUCTURE_SERVE_URL=http://192.168.1.140:7770/mineru_with_images
 ```
 
-The parse worker calls Unstructure-Serve with `return_txt=true`. It uses the
-returned `result` JSON for chunk embeddings and pickle generation, drops any
-returned chunk whose `text` is empty before embedding, and writes the returned
-whole-document `txt` payload as `{artifact_uuid}.txt` beside
-`{artifact_uuid}.pkl`.
+The parse worker can keep using that synchronous endpoint, or switch to
+Unstructure-Serve's internal two-stage Celery pipeline by setting:
 
-After MinerU returns chunks, the parse worker calls the OpenAI-compatible
-embedding endpoint before writing artifacts. The pickle artifact stores each
-remaining chunk with an `embedding` key, while the JSONL artifact omits
-embeddings to keep line-oriented inspection light. The worker requests
-provider-default Qwen3-Embedding-8B vectors, then locally truncates and
-normalizes them to the configured dimension:
+```text
+KB_PARSE_USE_TWO_STAGE=true
+UNSTRUCTURE_SERVE_TWO_STAGE_BASE_URL=http://192.168.1.140:7770
+KB_PARSE_TWO_STAGE_SUBMIT_TIMEOUT_SECONDS=120
+KB_PARSE_TWO_STAGE_STATUS_TIMEOUT_SECONDS=30
+KB_PARSE_TWO_STAGE_POLL_INTERVAL_SECONDS=3
+KB_PARSE_TWO_STAGE_PRIORITY=normal
+KB_PARSE_TWO_STAGE_CHUNK_TYPE=true
+```
+
+If `UNSTRUCTURE_SERVE_TWO_STAGE_BASE_URL` is omitted, the worker derives it from
+`UNSTRUCTURE_SERVE_URL` by removing a trailing `/mineru_with_images`, `/mineru`,
+or `/two_stage/task`. `UNSTRUCTURE_SERVE_BEARER_TOKEN` is reused for both
+submit and status polling. Optional `KB_PARSE_TWO_STAGE_PROVIDER`,
+`KB_PARSE_TWO_STAGE_MODEL`, and `KB_PARSE_TWO_STAGE_PROMPT` can override the
+parser-side vision defaults; leave them unset for normal deployment.
+
+Both modes request `return_txt=true`. The worker uses the returned `result` JSON
+for chunk embeddings and pickle generation, drops any returned chunk whose
+`text` is empty before embedding, and writes the returned whole-document `txt`
+payload as `{artifact_uuid}.txt` beside `{artifact_uuid}.pkl`.
+
+After MinerU returns chunks, the parse worker writes the raw parser chunks to a
+JSON artifact, splits chunks above the embedding token cap, and then calls the
+OpenAI-compatible embedding endpoint before writing the pickle artifact. Text
+chunks split on sentence or newline boundaries, table-like HTML chunks split on
+`<tr>` row boundaries, and oversized single sentences or rows fall back to a
+hard token split. The pickle artifact stores each embedding child chunk with an
+`embedding` key and parent metadata, while the JSONL artifact omits embeddings
+to keep line-oriented inspection light. The worker requests provider-default
+Qwen3-Embedding-8B vectors, then locally truncates and normalizes them to the
+configured dimension:
 
 ```text
 KB_EMBEDDING_BASE_URL=http://192.168.1.140:7710/v1
@@ -142,6 +165,7 @@ KB_EMBEDDING_MODEL=Qwen/Qwen3-Embedding-8B
 KB_EMBEDDING_API_KEY=EMPTY
 KB_EMBEDDING_DIMENSIONS=1536
 KB_EMBEDDING_BATCH_SIZE=32
+KB_EMBEDDING_CHUNK_MAX_TOKENS=8000
 KB_EMBEDDING_TIMEOUT_SECONDS=600
 ```
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-16
-lastReviewedCommit: 16836b132b4eb369a474bb570262cfb0a093addc
+lastReviewedAt: 2026-05-17
+lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -33,6 +33,7 @@ def write_processed_artifacts(
     parser_version: str,
     embedding: dict[str, Any] | None = None,
     full_text: str | None = None,
+    parser_result: list[Any] | None = None,
 ) -> tuple[Path, ArtifactInfo]:
     if not result:
         raise ValueError("EMPTY_RESULT")
@@ -48,6 +49,12 @@ def write_processed_artifacts(
     jsonl_path = tmp_dir / f"{artifact_uuid}.jsonl"
     pkl_path = tmp_dir / f"{artifact_uuid}.pkl"
     txt_path = tmp_dir / f"{artifact_uuid}.txt" if full_text is not None else None
+    parser_json_path = tmp_dir / f"{artifact_uuid}.json" if parser_result is not None else None
+    if parser_json_path is not None:
+        parser_json_path.write_text(
+            json.dumps(parser_result, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
     with jsonl_path.open("w", encoding="utf-8") as handle:
         for item in result:
             if isinstance(item, dict) and "embedding" in item:
@@ -66,6 +73,10 @@ def write_processed_artifacts(
         pickle.load(handle)
     if jsonl_path.stat().st_size <= 0 or pkl_path.stat().st_size <= 0:
         raise RuntimeError("ARTIFACT_VALIDATE_FAILED: empty artifact file")
+    if parser_json_path is not None:
+        parser_payload = json.loads(parser_json_path.read_text(encoding="utf-8"))
+        if not isinstance(parser_payload, list):
+            raise RuntimeError("ARTIFACT_VALIDATE_FAILED: parser json is not a list")
 
     manifest, _ = build_manifest(
         snapshot=snapshot,
@@ -74,6 +85,7 @@ def write_processed_artifacts(
         jsonl_path=jsonl_path,
         pkl_path=pkl_path,
         txt_path=txt_path,
+        parser_json_path=parser_json_path,
         parser_profile=parser_profile,
         parser_version=parser_version,
         embedding=embedding,
@@ -89,12 +101,15 @@ def write_processed_artifacts(
         jsonl_name=jsonl_path.name,
         pkl_name=pkl_path.name,
         txt_name=txt_path.name if txt_path is not None else None,
+        parser_json_name=parser_json_path.name if parser_json_path is not None else None,
         jsonl_sha256=manifest["sha256"]["chunks_jsonl"],
         pkl_sha256=manifest["sha256"]["chunks_pkl"],
         txt_sha256=manifest["sha256"].get("full_text_txt"),
+        parser_json_sha256=manifest["sha256"].get("parser_result_json"),
         jsonl_size_bytes=manifest["size_bytes"]["chunks_jsonl"],
         pkl_size_bytes=manifest["size_bytes"]["chunks_pkl"],
         txt_size_bytes=manifest["size_bytes"].get("full_text_txt"),
+        parser_json_size_bytes=manifest["size_bytes"].get("parser_result_json"),
         manifest_hash=manifest_hash,
         manifest=manifest,
     )

--- a/src/kb_parse_worker/chunk_splitter.py
+++ b/src/kb_parse_worker/chunk_splitter.py
@@ -1,0 +1,179 @@
+"""Token-aware chunk splitting for KB embedding inputs."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+class TokenCodec:
+    def __init__(self) -> None:
+        self._encoding = None
+        try:
+            import tiktoken
+
+            self._encoding = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            self._encoding = None
+
+    def count(self, text: str) -> int:
+        if self._encoding is not None:
+            return len(self._encoding.encode(text))
+        return len(text)
+
+    def split(self, text: str, max_tokens: int) -> list[str]:
+        if self.count(text) <= max_tokens:
+            return [text]
+        if self._encoding is not None:
+            tokens = self._encoding.encode(text)
+            return [
+                self._encoding.decode(tokens[offset : offset + max_tokens])
+                for offset in range(0, len(tokens), max_tokens)
+            ]
+        return [text[offset : offset + max_tokens] for offset in range(0, len(text), max_tokens)]
+
+
+_SENTENCE_RE = re.compile(r"[^。！？!?；;.\n]+[。！？!?；;.]*|\n+")
+_TR_RE = re.compile(r"<tr\b[^>]*>.*?</tr>", re.IGNORECASE | re.DOTALL)
+_TABLE_OPEN_RE = re.compile(r"<table\b[^>]*>", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class SplitStats:
+    source_chunk_count: int
+    output_chunk_count: int
+    split_parent_count: int
+
+
+def _chunk_text(item: Any) -> str:
+    if isinstance(item, dict):
+        text = item.get("text", "")
+        if text is None:
+            return ""
+        if isinstance(text, str):
+            return text
+        return json.dumps(text, ensure_ascii=False, sort_keys=True)
+    if isinstance(item, str):
+        return item
+    return json.dumps(item, ensure_ascii=False, sort_keys=True)
+
+
+def _sentence_units(text: str) -> list[str]:
+    units = [match.group(0) for match in _SENTENCE_RE.finditer(text) if match.group(0)]
+    return units or [text]
+
+
+def _pack_units(units: list[str], codec: TokenCodec, max_tokens: int) -> list[str]:
+    chunks: list[str] = []
+    current = ""
+    for unit in units:
+        if not unit:
+            continue
+        if codec.count(unit) > max_tokens:
+            if current.strip():
+                chunks.append(current)
+                current = ""
+            chunks.extend(codec.split(unit, max_tokens))
+            continue
+        candidate = f"{current}{unit}" if current else unit
+        if current and codec.count(candidate) > max_tokens:
+            chunks.append(current)
+            current = unit
+        else:
+            current = candidate
+    if current.strip():
+        chunks.append(current)
+    return [chunk for chunk in chunks if chunk.strip()]
+
+
+def _looks_like_html_table(text: str) -> bool:
+    stripped = text.lstrip().lower()
+    return stripped.startswith("<table") or ("<tr" in stripped and "</tr>" in stripped)
+
+
+def _table_wrapper(text: str) -> tuple[str, str]:
+    match = _TABLE_OPEN_RE.search(text)
+    if match:
+        return match.group(0), "</table>"
+    return "<table>", "</table>"
+
+
+def _split_table(text: str, codec: TokenCodec, max_tokens: int) -> list[str]:
+    rows = [match.group(0) for match in _TR_RE.finditer(text)]
+    if not rows:
+        return _pack_units(_sentence_units(text), codec, max_tokens)
+
+    open_tag, close_tag = _table_wrapper(text)
+    chunks: list[str] = []
+    current_rows: list[str] = []
+
+    def render(render_rows: list[str]) -> str:
+        return f"{open_tag}{''.join(render_rows)}{close_tag}"
+
+    for row in rows:
+        row_chunk = render([row])
+        if codec.count(row_chunk) > max_tokens:
+            if current_rows:
+                chunks.append(render(current_rows))
+                current_rows = []
+            chunks.extend(codec.split(row_chunk, max_tokens))
+            continue
+        candidate_rows = [*current_rows, row]
+        if current_rows and codec.count(render(candidate_rows)) > max_tokens:
+            chunks.append(render(current_rows))
+            current_rows = [row]
+        else:
+            current_rows = candidate_rows
+
+    if current_rows:
+        chunks.append(render(current_rows))
+    return [chunk for chunk in chunks if chunk.strip()]
+
+
+def _split_text(text: str, codec: TokenCodec, max_tokens: int) -> list[str]:
+    if codec.count(text) <= max_tokens:
+        return [text]
+    if _looks_like_html_table(text):
+        chunks = _split_table(text, codec, max_tokens)
+    else:
+        chunks = _pack_units(_sentence_units(text), codec, max_tokens)
+    final_chunks: list[str] = []
+    for chunk in chunks:
+        final_chunks.extend(codec.split(chunk, max_tokens))
+    return [chunk for chunk in final_chunks if chunk.strip()]
+
+
+def split_chunks_for_embedding(
+    chunks: list[Any],
+    document_id: str,
+    max_tokens: int,
+    codec: TokenCodec | None = None,
+) -> tuple[list[dict[str, Any]], SplitStats]:
+    if max_tokens <= 1:
+        raise ValueError("max_tokens must be greater than 1")
+    split_limit = max_tokens - 1
+    codec = codec or TokenCodec()
+    output: list[dict[str, Any]] = []
+    split_parent_count = 0
+
+    for parent_index, item in enumerate(chunks):
+        base = copy.deepcopy(item) if isinstance(item, dict) else {"text": _chunk_text(item)}
+        text = _chunk_text(base)
+        split_texts = _split_text(text, codec, split_limit)
+        if len(split_texts) > 1:
+            split_parent_count += 1
+        for split_text in split_texts:
+            if codec.count(split_text) >= max_tokens:
+                raise RuntimeError("CHUNK_SPLIT_VALIDATE_FAILED")
+            child = dict(base)
+            child["text"] = split_text
+            output.append(child)
+
+    return output, SplitStats(
+        source_chunk_count=len(chunks),
+        output_chunk_count=len(output),
+        split_parent_count=split_parent_count,
+    )

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -32,6 +32,23 @@ def _bool_env(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _optional_str_env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _infer_two_stage_base_url(api_url: str) -> str:
+    trimmed = api_url.rstrip("/")
+    for suffix in ("/mineru_with_images", "/mineru", "/two_stage/task"):
+        if trimmed.endswith(suffix):
+            trimmed = trimmed[: -len(suffix)]
+            break
+    return trimmed.rstrip("/")
+
+
 def database_url_from_env() -> str:
     for name in ("DATABASE_URL", "SUPABASE_DB_URL", "KB_DATABASE_URL"):
         value = os.getenv(name)
@@ -77,6 +94,16 @@ class WorkerConfig:
     nas_processed_root: Path
     unstructure_serve_url: str
     unstructure_serve_bearer_token: str
+    use_two_stage_parser: bool
+    unstructure_serve_two_stage_base_url: str
+    two_stage_submit_timeout_seconds: int
+    two_stage_status_timeout_seconds: int
+    two_stage_poll_interval_seconds: int
+    two_stage_priority: str
+    two_stage_chunk_type: bool
+    two_stage_provider: str | None
+    two_stage_model: str | None
+    two_stage_prompt: str | None
     parser_profile: str
     parser_version: str
     s3_ready_mode: str
@@ -90,6 +117,7 @@ class WorkerConfig:
     embedding_api_key: str
     embedding_dimensions: int
     embedding_batch_size: int
+    embedding_chunk_max_tokens: int
     embedding_timeout_seconds: int
     parse_job_timeout_seconds: int
     s3_ready_job_timeout_seconds: int
@@ -125,6 +153,25 @@ class WorkerConfig:
             nas_processed_root=Path(nas_processed_root),
             unstructure_serve_url=unstructure_url,
             unstructure_serve_bearer_token=token,
+            use_two_stage_parser=_bool_env("KB_PARSE_USE_TWO_STAGE", False),
+            unstructure_serve_two_stage_base_url=os.getenv(
+                "UNSTRUCTURE_SERVE_TWO_STAGE_BASE_URL",
+                _infer_two_stage_base_url(unstructure_url),
+            ).rstrip("/"),
+            two_stage_submit_timeout_seconds=_positive_int_env(
+                "KB_PARSE_TWO_STAGE_SUBMIT_TIMEOUT_SECONDS", 120
+            ),
+            two_stage_status_timeout_seconds=_positive_int_env(
+                "KB_PARSE_TWO_STAGE_STATUS_TIMEOUT_SECONDS", 30
+            ),
+            two_stage_poll_interval_seconds=_positive_int_env(
+                "KB_PARSE_TWO_STAGE_POLL_INTERVAL_SECONDS", 3
+            ),
+            two_stage_priority=os.getenv("KB_PARSE_TWO_STAGE_PRIORITY", "normal"),
+            two_stage_chunk_type=_bool_env("KB_PARSE_TWO_STAGE_CHUNK_TYPE", True),
+            two_stage_provider=_optional_str_env("KB_PARSE_TWO_STAGE_PROVIDER"),
+            two_stage_model=_optional_str_env("KB_PARSE_TWO_STAGE_MODEL"),
+            two_stage_prompt=_optional_str_env("KB_PARSE_TWO_STAGE_PROMPT"),
             parser_profile=os.getenv("KB_PARSE_PARSER_PROFILE", "mineru_with_images"),
             parser_version=os.getenv("KB_PARSE_PARSER_VERSION", "unstructure-serve"),
             s3_ready_mode=os.getenv("KB_PARSE_S3_READY_MODE", "check"),
@@ -140,6 +187,7 @@ class WorkerConfig:
             embedding_api_key=os.getenv("KB_EMBEDDING_API_KEY", "EMPTY"),
             embedding_dimensions=_positive_int_env("KB_EMBEDDING_DIMENSIONS", 1536),
             embedding_batch_size=_positive_int_env("KB_EMBEDDING_BATCH_SIZE", 32),
+            embedding_chunk_max_tokens=_positive_int_env("KB_EMBEDDING_CHUNK_MAX_TOKENS", 8000),
             embedding_timeout_seconds=_positive_int_env("KB_EMBEDDING_TIMEOUT_SECONDS", 600),
             parse_job_timeout_seconds=_positive_int_env("KB_PARSE_JOB_TIMEOUT_SECONDS", 7200),
             s3_ready_job_timeout_seconds=_positive_int_env(

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -19,12 +19,15 @@ class ArtifactInfo:
     jsonl_name: str
     pkl_name: str
     txt_name: str | None
+    parser_json_name: str | None
     jsonl_sha256: str
     pkl_sha256: str
     txt_sha256: str | None
+    parser_json_sha256: str | None
     jsonl_size_bytes: int
     pkl_size_bytes: int
     txt_size_bytes: int | None
+    parser_json_size_bytes: int | None
     manifest_hash: str
     manifest: dict[str, Any]
 
@@ -44,6 +47,7 @@ def build_manifest(
     jsonl_path: Path,
     pkl_path: Path,
     txt_path: Path | None,
+    parser_json_path: Path | None,
     parser_profile: str,
     parser_version: str,
     embedding: dict[str, Any] | None = None,
@@ -66,6 +70,10 @@ def build_manifest(
         artifacts["full_text_txt"] = txt_path.name
         sha256["full_text_txt"] = file_sha256(txt_path)
         size_bytes["full_text_txt"] = txt_path.stat().st_size
+    if parser_json_path is not None:
+        artifacts["parser_result_json"] = parser_json_path.name
+        sha256["parser_result_json"] = file_sha256(parser_json_path)
+        size_bytes["parser_result_json"] = parser_json_path.stat().st_size
 
     manifest = {
         "document_id": snapshot.document_id,
@@ -108,12 +116,23 @@ def load_artifact_info(manifest_path: Path, manifest_hash: str | None = None) ->
         jsonl_name=str(artifacts["chunks_jsonl"]),
         pkl_name=str(artifacts["chunks_pkl"]),
         txt_name=str(artifacts["full_text_txt"]) if artifacts.get("full_text_txt") else None,
+        parser_json_name=(
+            str(artifacts["parser_result_json"]) if artifacts.get("parser_result_json") else None
+        ),
         jsonl_sha256=str(sha256["chunks_jsonl"]),
         pkl_sha256=str(sha256["chunks_pkl"]),
         txt_sha256=str(sha256["full_text_txt"]) if sha256.get("full_text_txt") else None,
+        parser_json_sha256=(
+            str(sha256["parser_result_json"]) if sha256.get("parser_result_json") else None
+        ),
         jsonl_size_bytes=int(size_bytes["chunks_jsonl"]),
         pkl_size_bytes=int(size_bytes["chunks_pkl"]),
         txt_size_bytes=int(size_bytes["full_text_txt"]) if size_bytes.get("full_text_txt") is not None else None,
+        parser_json_size_bytes=(
+            int(size_bytes["parser_result_json"])
+            if size_bytes.get("parser_result_json") is not None
+            else None
+        ),
         manifest_hash=manifest_hash or file_sha256(manifest_path),
         manifest=manifest,
     )

--- a/src/kb_parse_worker/parser_adapter.py
+++ b/src/kb_parse_worker/parser_adapter.py
@@ -1,7 +1,8 @@
-"""HTTP adapter for Unstructure-Serve /mineru_with_images."""
+"""HTTP adapter for Unstructure-Serve parser APIs."""
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,14 @@ import requests
 
 
 class ParserError(RuntimeError):
+    pass
+
+
+class ParserTimeout(ParserError):
+    pass
+
+
+class ParserTaskFailure(ParserError):
     pass
 
 
@@ -35,29 +44,16 @@ def filter_empty_text_chunks(result: list[Any]) -> tuple[list[Any], int]:
     return filtered, len(result) - len(filtered)
 
 
-def parse_with_unstructure_serve(
-    raw_path: Path,
-    api_url: str,
-    bearer_token: str,
-    timeout_seconds: int = 3600,
-    return_txt: bool = True,
-) -> ParsedDocument:
-    headers = {"Authorization": f"Bearer {bearer_token}"}
-    with raw_path.open("rb") as handle:
-        response = requests.post(
-            api_url,
-            files={"file": (raw_path.name, handle)},
-            params={"return_txt": "true" if return_txt else "false"},
-            data={"return_txt": "true" if return_txt else "false"},
-            headers=headers,
-            timeout=timeout_seconds,
-        )
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as exc:
-        raise ParserError(f"parser http error {response.status_code}: {response.text[:500]}") from exc
+def infer_two_stage_base_url(api_url: str) -> str:
+    trimmed = api_url.rstrip("/")
+    for suffix in ("/mineru_with_images", "/mineru", "/two_stage/task"):
+        if trimmed.endswith(suffix):
+            trimmed = trimmed[: -len(suffix)]
+            break
+    return trimmed.rstrip("/")
 
-    payload = response.json()
+
+def _parsed_document_from_payload(payload: dict[str, Any], return_txt: bool) -> ParsedDocument:
     if "result" not in payload:
         raise ParserError("parser response missing result")
     result = payload["result"]
@@ -75,3 +71,133 @@ def parse_with_unstructure_serve(
         original_chunk_count=len(result),
         dropped_empty_text_count=dropped_count,
     )
+
+
+def _raise_for_parser_status(response: requests.Response) -> None:
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise ParserError(f"parser http error {response.status_code}: {response.text[:500]}") from exc
+
+
+def _parse_with_two_stage(
+    raw_path: Path,
+    base_url: str,
+    bearer_token: str,
+    *,
+    timeout_seconds: int,
+    return_txt: bool,
+    submit_timeout_seconds: int,
+    status_timeout_seconds: int,
+    poll_interval_seconds: int,
+    priority: str,
+    chunk_type: bool,
+    provider: str | None,
+    model: str | None,
+    prompt: str | None,
+) -> ParsedDocument:
+    if timeout_seconds <= 0:
+        raise ParserTimeout("parser two-stage timeout before submit")
+    deadline = time.monotonic() + timeout_seconds
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    submit_url = f"{base_url.rstrip('/')}/two_stage/task"
+    status_base_url = submit_url
+    form_data: dict[str, str] = {
+        "return_txt": "true" if return_txt else "false",
+        "chunk_type": "true" if chunk_type else "false",
+        "priority": priority or "normal",
+    }
+    if provider:
+        form_data["provider"] = provider
+    if model:
+        form_data["model"] = model
+    if prompt:
+        form_data["prompt"] = prompt
+
+    with raw_path.open("rb") as handle:
+        response = requests.post(
+            submit_url,
+            files={"file": (raw_path.name, handle)},
+            data=form_data,
+            headers=headers,
+            timeout=min(submit_timeout_seconds, max(1, int(deadline - time.monotonic()))),
+        )
+    _raise_for_parser_status(response)
+    submit_payload = response.json()
+    task_id = submit_payload.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        raise ParserError("parser response missing task_id")
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ParserTimeout(f"parser two-stage task {task_id} timed out")
+        status_response = requests.get(
+            f"{status_base_url}/{task_id}",
+            headers=headers,
+            timeout=min(status_timeout_seconds, max(1, int(remaining))),
+        )
+        _raise_for_parser_status(status_response)
+        status_payload = status_response.json()
+        state = status_payload.get("state")
+        if state == "SUCCESS":
+            result_payload = status_payload.get("result")
+            if not isinstance(result_payload, dict):
+                raise ParserError("parser response missing result payload")
+            return _parsed_document_from_payload(result_payload, return_txt)
+        if state in {"FAILURE", "REVOKED"}:
+            error_detail = status_payload.get("error") or state
+            raise ParserTaskFailure(f"parser two-stage task {task_id} failed: {error_detail}")
+        if not isinstance(state, str) or not state:
+            raise ParserError("parser response missing state")
+        time.sleep(min(poll_interval_seconds, max(0.1, deadline - time.monotonic())))
+
+
+def parse_with_unstructure_serve(
+    raw_path: Path,
+    api_url: str,
+    bearer_token: str,
+    timeout_seconds: int = 3600,
+    return_txt: bool = True,
+    *,
+    use_two_stage: bool = False,
+    two_stage_base_url: str | None = None,
+    two_stage_submit_timeout_seconds: int = 120,
+    two_stage_status_timeout_seconds: int = 30,
+    two_stage_poll_interval_seconds: int = 3,
+    two_stage_priority: str = "normal",
+    two_stage_chunk_type: bool = True,
+    two_stage_provider: str | None = None,
+    two_stage_model: str | None = None,
+    two_stage_prompt: str | None = None,
+) -> ParsedDocument:
+    if use_two_stage:
+        return _parse_with_two_stage(
+            raw_path,
+            two_stage_base_url or infer_two_stage_base_url(api_url),
+            bearer_token,
+            timeout_seconds=timeout_seconds,
+            return_txt=return_txt,
+            submit_timeout_seconds=two_stage_submit_timeout_seconds,
+            status_timeout_seconds=two_stage_status_timeout_seconds,
+            poll_interval_seconds=two_stage_poll_interval_seconds,
+            priority=two_stage_priority,
+            chunk_type=two_stage_chunk_type,
+            provider=two_stage_provider,
+            model=two_stage_model,
+            prompt=two_stage_prompt,
+        )
+
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    with raw_path.open("rb") as handle:
+        response = requests.post(
+            api_url,
+            files={"file": (raw_path.name, handle)},
+            params={"return_txt": "true" if return_txt else "false"},
+            data={"return_txt": "true" if return_txt else "false"},
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+    _raise_for_parser_status(response)
+
+    return _parsed_document_from_payload(response.json(), return_txt)

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-from contextlib import nullcontext
 import logging
 import threading
 import time
@@ -14,10 +13,16 @@ import requests
 
 from . import control_plane, queue
 from .artifacts import write_processed_artifacts
+from .chunk_splitter import split_chunks_for_embedding
 from .config import WorkerConfig
 from .embedding_client import EmbeddingError, add_chunk_embeddings
 from .manifest import load_artifact_info
-from .parser_adapter import ParserError, parse_with_unstructure_serve
+from .parser_adapter import (
+    ParserError,
+    ParserTaskFailure,
+    ParserTimeout,
+    parse_with_unstructure_serve,
+)
 from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
 from .snapshot import (
     load_parse_snapshot,
@@ -86,6 +91,10 @@ def is_parse_failure_retryable(error: Exception) -> bool:
     if message.startswith("embedding response "):
         return False
 
+    if isinstance(error, ParserTimeout):
+        return True
+    if isinstance(error, ParserTaskFailure):
+        return True
     if isinstance(error, ParserError):
         return _is_retryable_http_status(_http_status_from_message("parser http error ", message))
     if isinstance(error, EmbeddingError):
@@ -114,6 +123,49 @@ def archive_current_message(conn, queue_name: str, msg_id: int) -> bool:
     return queue.archive_job_message_by_id(conn, queue_name, msg_id)
 
 
+def read_queue_message(
+    config: WorkerConfig,
+    queue_name: str,
+) -> queue.QueueMessage | None:
+    with control_plane.connect(config.database_url) as conn:
+        return queue.read_one(conn, queue_name, config.queue_vt_seconds)
+
+
+def claim_queue_message(
+    config: WorkerConfig,
+    queue_name: str,
+    message: queue.QueueMessage,
+) -> control_plane.ClaimJobResult | None:
+    with control_plane.connect(config.database_url) as conn:
+        claim = control_plane.claim_job(
+            conn,
+            message.job_id,
+            queue_name,
+            message.msg_id,
+            config.worker_id,
+            config.lock_seconds,
+        )
+        if claim is None or not claim.claimed:
+            handle_unclaimed_message(conn, queue_name, message, claim)
+        return claim
+
+
+def load_parse_snapshot_with_short_connection(
+    config: WorkerConfig,
+    job_id: str,
+):
+    with control_plane.connect(config.database_url) as conn:
+        return load_parse_snapshot(conn, job_id)
+
+
+def load_s3_ready_snapshot_with_short_connection(
+    config: WorkerConfig,
+    job_id: str,
+):
+    with control_plane.connect(config.database_url) as conn:
+        return load_s3_ready_snapshot(conn, job_id)
+
+
 def _is_retryable_finalization_error(error: Exception) -> bool:
     return isinstance(error, (psycopg2.InterfaceError, psycopg2.OperationalError))
 
@@ -124,7 +176,6 @@ def _finalization_backoff_seconds(attempt: int) -> float:
 
 def complete_parse_local_ready_and_archive_with_retry(
     config: WorkerConfig,
-    conn,
     job_id: str,
     document_id: str,
     document_version: int,
@@ -142,13 +193,8 @@ def complete_parse_local_ready_and_archive_with_retry(
         raise ValueError("max_attempts must be positive")
 
     for attempt in range(1, max_attempts + 1):
-        connection_context = (
-            nullcontext(conn)
-            if attempt == 1
-            else control_plane.connect(config.database_url)
-        )
         try:
-            with connection_context as active_conn:
+            with control_plane.connect(config.database_url) as active_conn:
                 result = control_plane.complete_parse_local_ready_and_enqueue_s3_check(
                     active_conn,
                     job_id,
@@ -207,7 +253,6 @@ def handle_unclaimed_message(
 
 def fail_job_and_archive_current_message(
     config: WorkerConfig,
-    conn,
     job_id: str,
     queue_name: str,
     msg_id: int,
@@ -221,13 +266,8 @@ def fail_job_and_archive_current_message(
         raise ValueError("max_attempts must be positive")
 
     for attempt in range(1, max_attempts + 1):
-        connection_context = (
-            nullcontext(conn)
-            if attempt == 1
-            else control_plane.connect(config.database_url)
-        )
         try:
-            with connection_context as active_conn:
+            with control_plane.connect(config.database_url) as active_conn:
                 result = control_plane.fail_job(
                     active_conn,
                     job_id,
@@ -264,7 +304,6 @@ def fail_job_and_archive_current_message(
 
 def complete_s3_ready_check_and_archive_with_retry(
     config: WorkerConfig,
-    conn,
     job_id: str,
     document_id: str,
     document_version: int,
@@ -281,13 +320,8 @@ def complete_s3_ready_check_and_archive_with_retry(
         raise ValueError("max_attempts must be positive")
 
     for attempt in range(1, max_attempts + 1):
-        connection_context = (
-            nullcontext(conn)
-            if attempt == 1
-            else control_plane.connect(config.database_url)
-        )
         try:
-            with connection_context as active_conn:
+            with control_plane.connect(config.database_url) as active_conn:
                 ok = control_plane.complete_s3_ready_check(
                     active_conn,
                     job_id,
@@ -395,29 +429,19 @@ class ParseWorker:
                 time.sleep(self.config.poll_interval_seconds)
 
     def run_once(self) -> bool:
-        with control_plane.connect(self.config.database_url) as conn:
-            message = queue.read_one(conn, self.config.queue_name, self.config.queue_vt_seconds)
-            if message is None:
-                return False
-            self.process_message(conn, message)
-            return True
+        message = read_queue_message(self.config, self.config.queue_name)
+        if message is None:
+            return False
+        self.process_message(message)
+        return True
 
-    def process_message(self, conn, message: queue.QueueMessage) -> None:
-        claimed = control_plane.claim_job(
-            conn,
-            message.job_id,
-            self.config.queue_name,
-            message.msg_id,
-            self.config.worker_id,
-            self.config.lock_seconds,
-        )
+    def process_message(self, message: queue.QueueMessage) -> None:
+        claimed = claim_queue_message(self.config, self.config.queue_name, message)
         if claimed is None or not claimed.claimed:
-            handle_unclaimed_message(conn, self.config.queue_name, message, claimed)
             return
         if claimed.stage != "parse":
             fail_job_and_archive_current_message(
                 self.config,
-                conn,
                 claimed.job_id,
                 self.config.queue_name,
                 message.msg_id,
@@ -432,7 +456,10 @@ class ParseWorker:
             with LeaseMaintainer(self.config, claimed.job_id) as lease:
                 deadline = JobDeadline("parse", self.config.parse_job_timeout_seconds)
                 deadline.check()
-                snapshot = load_parse_snapshot(conn, claimed.job_id)
+                snapshot = load_parse_snapshot_with_short_connection(
+                    self.config,
+                    claimed.job_id,
+                )
                 if snapshot.processed_manifest_local_uri and snapshot.processed_artifact_uuid:
                     manifest_path = Path(snapshot.processed_manifest_local_uri)
                     artifact_info = load_artifact_info(manifest_path, snapshot.processed_manifest_hash)
@@ -466,6 +493,22 @@ class ParseWorker:
                         timeout_seconds=deadline.remaining_seconds(
                             self.config.parse_job_timeout_seconds
                         ),
+                        use_two_stage=self.config.use_two_stage_parser,
+                        two_stage_base_url=self.config.unstructure_serve_two_stage_base_url,
+                        two_stage_submit_timeout_seconds=(
+                            self.config.two_stage_submit_timeout_seconds
+                        ),
+                        two_stage_status_timeout_seconds=(
+                            self.config.two_stage_status_timeout_seconds
+                        ),
+                        two_stage_poll_interval_seconds=(
+                            self.config.two_stage_poll_interval_seconds
+                        ),
+                        two_stage_priority=self.config.two_stage_priority,
+                        two_stage_chunk_type=True,
+                        two_stage_provider=self.config.two_stage_provider,
+                        two_stage_model=self.config.two_stage_model,
+                        two_stage_prompt=self.config.two_stage_prompt,
                     )
                     result = parsed.result
                     if parsed.dropped_empty_text_count:
@@ -478,8 +521,24 @@ class ParseWorker:
                     lease.check()
                     deadline.check()
 
-                    result = add_chunk_embeddings(
+                    embedding_chunks, split_stats = split_chunks_for_embedding(
                         result,
+                        snapshot.document_id,
+                        self.config.embedding_chunk_max_tokens,
+                    )
+                    if split_stats.split_parent_count:
+                        LOGGER.info(
+                            "parse job %s split %s/%s parser chunk(s) into %s embedding chunk(s)",
+                            claimed.job_id,
+                            split_stats.split_parent_count,
+                            split_stats.source_chunk_count,
+                            split_stats.output_chunk_count,
+                        )
+                    lease.check()
+                    deadline.check()
+
+                    embedded_result = add_chunk_embeddings(
+                        embedding_chunks,
                         self.config.embedding_base_url,
                         self.config.embedding_model,
                         self.config.embedding_api_key,
@@ -497,15 +556,20 @@ class ParseWorker:
                         "dimensions": self.config.embedding_dimensions,
                         "normalized": True,
                         "source_dimensions": "provider_default",
+                        "chunk_max_tokens": self.config.embedding_chunk_max_tokens,
+                        "source_chunk_count": split_stats.source_chunk_count,
+                        "embedding_chunk_count": split_stats.output_chunk_count,
+                        "split_parent_count": split_stats.split_parent_count,
                     }
                     final_dir, artifact_info = write_processed_artifacts(
-                        result,
+                        embedded_result,
                         snapshot,
                         self.config.nas_processed_root,
                         self.config.parser_profile,
                         self.config.parser_version,
                         embedding_metadata,
                         parsed.txt,
+                        result,
                     )
                     lease.check()
                     deadline.check()
@@ -536,7 +600,6 @@ class ParseWorker:
                 }
                 s3_ready_result = complete_parse_local_ready_and_archive_with_retry(
                     self.config,
-                    conn,
                     claimed.job_id,
                     claimed.document_id,
                     claimed.document_version,
@@ -560,7 +623,6 @@ class ParseWorker:
             retryable = is_parse_failure_retryable(exc)
             fail_job_and_archive_current_message(
                 self.config,
-                conn,
                 claimed.job_id,
                 self.config.queue_name,
                 message.msg_id,
@@ -582,33 +644,19 @@ class S3ReadyWorker:
                 time.sleep(self.config.poll_interval_seconds)
 
     def run_once(self) -> bool:
-        with control_plane.connect(self.config.database_url) as conn:
-            message = queue.read_one(
-                conn,
-                self.config.s3_ready_queue_name,
-                self.config.queue_vt_seconds,
-            )
-            if message is None:
-                return False
-            self.process_message(conn, message)
-            return True
+        message = read_queue_message(self.config, self.config.s3_ready_queue_name)
+        if message is None:
+            return False
+        self.process_message(message)
+        return True
 
-    def process_message(self, conn, message: queue.QueueMessage) -> None:
-        claimed = control_plane.claim_job(
-            conn,
-            message.job_id,
-            self.config.s3_ready_queue_name,
-            message.msg_id,
-            self.config.worker_id,
-            self.config.lock_seconds,
-        )
+    def process_message(self, message: queue.QueueMessage) -> None:
+        claimed = claim_queue_message(self.config, self.config.s3_ready_queue_name, message)
         if claimed is None or not claimed.claimed:
-            handle_unclaimed_message(conn, self.config.s3_ready_queue_name, message, claimed)
             return
         if claimed.stage != "s3_ready":
             fail_job_and_archive_current_message(
                 self.config,
-                conn,
                 claimed.job_id,
                 self.config.s3_ready_queue_name,
                 message.msg_id,
@@ -623,7 +671,10 @@ class S3ReadyWorker:
             with LeaseMaintainer(self.config, claimed.job_id) as lease:
                 deadline = JobDeadline("s3_ready", self.config.s3_ready_job_timeout_seconds)
                 deadline.check()
-                snapshot = load_s3_ready_snapshot(conn, claimed.job_id)
+                snapshot = load_s3_ready_snapshot_with_short_connection(
+                    self.config,
+                    claimed.job_id,
+                )
                 if not snapshot.processed_manifest_local_uri:
                     raise RuntimeError("LOCAL_MANIFEST_MISSING")
                 manifest_path = Path(snapshot.processed_manifest_local_uri)
@@ -651,7 +702,6 @@ class S3ReadyWorker:
 
                 ok = complete_s3_ready_check_and_archive_with_retry(
                     self.config,
-                    conn,
                     claimed.job_id,
                     claimed.document_id,
                     claimed.document_version,
@@ -670,7 +720,6 @@ class S3ReadyWorker:
             retryable = is_s3_ready_failure_retryable(exc)
             fail_job_and_archive_current_message(
                 self.config,
-                conn,
                 claimed.job_id,
                 self.config.s3_ready_queue_name,
                 message.msg_id,

--- a/tests/test_kb_parse_worker_artifacts.py
+++ b/tests/test_kb_parse_worker_artifacts.py
@@ -109,6 +109,74 @@ class KbParseWorkerArtifactTests(unittest.TestCase):
                         "token",
                     )
 
+    def test_parse_with_unstructure_serve_two_stage_polls_success(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as raw_file:
+            raw_file.write(b"%PDF")
+            raw_file.flush()
+            submit_response = self.FakeResponse({"task_id": "task-1", "state": "PENDING"})
+            pending_response = self.FakeResponse({"task_id": "task-1", "state": "STARTED"})
+            success_response = self.FakeResponse(
+                {
+                    "task_id": "task-1",
+                    "state": "SUCCESS",
+                    "result": {
+                        "result": [{"text": "chunk"}, {"text": ""}],
+                        "txt": "whole document text",
+                    },
+                }
+            )
+
+            with (
+                patch(
+                    "src.kb_parse_worker.parser_adapter.requests.post",
+                    return_value=submit_response,
+                ) as post,
+                patch(
+                    "src.kb_parse_worker.parser_adapter.requests.get",
+                    side_effect=[pending_response, success_response],
+                ) as get,
+                patch("src.kb_parse_worker.parser_adapter.time.sleep") as sleep,
+            ):
+                parsed = parse_with_unstructure_serve(
+                    Path(raw_file.name),
+                    "https://parser.test/mineru_with_images",
+                    "token",
+                    use_two_stage=True,
+                    two_stage_submit_timeout_seconds=10,
+                    two_stage_status_timeout_seconds=10,
+                    two_stage_poll_interval_seconds=1,
+                    two_stage_priority="urgent",
+                    two_stage_chunk_type=True,
+                    two_stage_provider="vllm",
+                    two_stage_model="model",
+                    two_stage_prompt="prompt",
+                )
+
+            self.assertEqual(parsed.result, [{"text": "chunk"}])
+            self.assertEqual(parsed.txt, "whole document text")
+            self.assertEqual(parsed.original_chunk_count, 2)
+            self.assertEqual(parsed.dropped_empty_text_count, 1)
+            self.assertEqual(post.call_args.args[0], "https://parser.test/two_stage/task")
+            self.assertEqual(
+                post.call_args.kwargs["data"],
+                {
+                    "return_txt": "true",
+                    "chunk_type": "true",
+                    "priority": "urgent",
+                    "provider": "vllm",
+                    "model": "model",
+                    "prompt": "prompt",
+                },
+            )
+            self.assertEqual(
+                [call.args[0] for call in get.call_args_list],
+                [
+                    "https://parser.test/two_stage/task/task-1",
+                    "https://parser.test/two_stage/task/task-1",
+                ],
+            )
+            sleep.assert_called_once()
+
     def test_write_processed_artifacts_writes_full_text_txt(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             final_dir, artifact_info = write_processed_artifacts(
@@ -129,6 +197,38 @@ class KbParseWorkerArtifactTests(unittest.TestCase):
             self.assertEqual((final_dir / txt_name).read_text(encoding="utf-8"), "whole document text")
             self.assertEqual(artifact_info.txt_name, txt_name)
             self.assertEqual(manifest["size_bytes"]["full_text_txt"], len("whole document text"))
+
+    def test_write_processed_artifacts_writes_parser_result_json(self) -> None:
+        parser_result = [{"text": "raw chunk", "page_number": 1}]
+        embedded_result = [
+            {
+                "text": "raw chunk",
+                "page_number": 1,
+                "type": "text",
+                "embedding": [0.1, 0.2],
+            }
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            final_dir, artifact_info = write_processed_artifacts(
+                embedded_result,
+                snapshot(),
+                Path(temp_dir),
+                "profile",
+                "version",
+                {"model": "embedding"},
+                "whole document text",
+                parser_result,
+            )
+
+            manifest = json.loads((final_dir / "manifest.json").read_text(encoding="utf-8"))
+            parser_json_name = manifest["artifacts"]["parser_result_json"]
+
+            self.assertEqual(parser_json_name, f"{manifest['artifact_uuid']}.json")
+            self.assertEqual(
+                json.loads((final_dir / parser_json_name).read_text(encoding="utf-8")),
+                parser_result,
+            )
+            self.assertEqual(artifact_info.parser_json_name, parser_json_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_kb_parse_worker_chunk_splitter.py
+++ b/tests/test_kb_parse_worker_chunk_splitter.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+from src.kb_parse_worker.chunk_splitter import split_chunks_for_embedding
+
+
+class CharCodec:
+    def count(self, text: str) -> int:
+        return len(text)
+
+    def split(self, text: str, max_tokens: int) -> list[str]:
+        return [text[offset : offset + max_tokens] for offset in range(0, len(text), max_tokens)]
+
+
+class KbParseWorkerChunkSplitterTests(unittest.TestCase):
+    def test_splits_text_on_sentence_boundaries(self) -> None:
+        chunks, stats = split_chunks_for_embedding(
+            [{"text": "第一句。第二句。第三句。", "page_number": 1, "type": "text"}],
+            "doc-1",
+            9,
+            CharCodec(),
+        )
+
+        self.assertEqual([chunk["text"] for chunk in chunks], ["第一句。第二句。", "第三句。"])
+        self.assertEqual(stats.source_chunk_count, 1)
+        self.assertEqual(stats.output_chunk_count, 2)
+        self.assertEqual(stats.split_parent_count, 1)
+        self.assertEqual(set(chunks[0]), {"text", "page_number", "type"})
+        self.assertEqual(set(chunks[1]), {"text", "page_number", "type"})
+
+    def test_splits_html_table_on_row_boundaries(self) -> None:
+        table = "<table><tr><td>aa</td></tr><tr><td>bb</td></tr><tr><td>cc</td></tr></table>"
+        chunks, stats = split_chunks_for_embedding(
+            [{"text": table, "page_number": 2}],
+            "doc-1",
+            50,
+            CharCodec(),
+        )
+
+        self.assertEqual(stats.output_chunk_count, 3)
+        self.assertTrue(all(chunk["text"].startswith("<table>") for chunk in chunks))
+        self.assertTrue(all(chunk["text"].endswith("</table>") for chunk in chunks))
+        self.assertIn("<tr><td>aa</td></tr>", chunks[0]["text"])
+        self.assertIn("<tr><td>bb</td></tr>", chunks[1]["text"])
+        self.assertIn("<tr><td>cc</td></tr>", chunks[2]["text"])
+
+    def test_hard_splits_single_oversized_sentence(self) -> None:
+        chunks, _ = split_chunks_for_embedding(
+            [{"text": "abcdefghij", "page_number": 3}],
+            "doc-1",
+            4,
+            CharCodec(),
+        )
+
+        self.assertEqual([chunk["text"] for chunk in chunks], ["abc", "def", "ghi", "j"])
+        self.assertTrue(all(len(chunk["text"]) < 4 for chunk in chunks))
+
+    def test_unsplit_chunks_keep_original_keys_only(self) -> None:
+        chunks, stats = split_chunks_for_embedding(
+            [{"text": "short", "page_number": 4}],
+            "doc-1",
+            8000,
+            CharCodec(),
+        )
+
+        self.assertEqual(stats.output_chunk_count, 1)
+        self.assertEqual(chunks[0], {"text": "short", "page_number": 4})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional two-stage parser mode for the KB parse worker
- add parser polling, timeout/failure handling, and chunk token splitting
- update repo docs and tests for the new worker behavior

## Validation
- `.venv/bin/python -m pytest tests/test_kb_parse_worker_artifacts.py tests/test_kb_parse_worker_chunk_splitter.py`
- `docpact validate-config --root . --strict --format json`
- `docpact lint --root . --staged --format json --output .docpact/runs/latest-push-prep.json`