### PR TITLE
[codex] Remove KB parse JSONL artifact output

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-17"
-lastReviewedCommit: "1a689ec9260599e88a35283e614364c82de5e44f"
+lastReviewedAt: "2026-05-20"
+lastReviewedCommit: "eda42e5c0a485212b71a8aefc808574fa0bf013a"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Unstructure Architecture

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -57,7 +57,7 @@ the referenced files still exist.
 - The KB parse worker reads raw document locations from `kb_documents.raw_uri`,
   requires raw files to live under the collection-derived storage path using
   the renamed canonical filename `{document_id}{file_ext}`, writes processed
-  `jsonl`/`pkl`/`txt`/`manifest.json` artifacts under the configured NAS
+  `json`/`pkl`/`txt`/`manifest.json` artifacts under the configured NAS
   processed root using a `_pickle` suffixed path derived from the collection
   storage path, and calls `complete_parse_local_ready_and_enqueue_s3_check(...)`.
   The worker requests `return_txt=true` from Unstructure-Serve in both sync and
@@ -67,9 +67,8 @@ the referenced files still exist.
   Before artifact writes, the worker stores the parser result as a JSON artifact,
   splits chunks above the embedding token cap into child chunks, embeds every
   child chunk `text` field through the OpenAI-compatible Qwen3-Embedding-8B
-  endpoint, locally truncates and normalizes vectors to 1536 dimensions, stores
-  vectors in the pickle chunks under `embedding`, and excludes `embedding` from
-  the JSONL artifact.
+  endpoint, locally truncates and normalizes vectors to 1536 dimensions, and
+  stores vectors in the pickle chunks under `embedding`.
   That RPC completes the parse job, leaves the document in `s3_sync_pending`,
   and enqueues a durable `s3_ready` job. The parse worker treats that final
   local-ready RPC plus parse-message archive as one finalization step. A parse
@@ -77,7 +76,7 @@ the referenced files still exist.
   processed artifacts already exist on NAS but the final DB handoff did not
   commit; it validates the local manifest identity and replays the local-ready
   DB transition without re-running document parsing. A
-  separate S3-ready worker then verifies the processed manifest/jsonl/pkl/txt
+  separate S3-ready worker then verifies the processed manifest/json/pkl/txt
   objects after NAS-to-S3 sync and calls `complete_s3_ready_check(...)` to mark
   `processed_s3_ready`. Final DB transitions and failure writes retry transient
   Postgres connection failures with short reconnecting backoff. PM2 keeps

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -154,8 +154,8 @@ OpenAI-compatible embedding endpoint before writing the pickle artifact. Text
 chunks split on sentence or newline boundaries, table-like HTML chunks split on
 `<tr>` row boundaries, and oversized single sentences or rows fall back to a
 hard token split. The pickle artifact stores each embedding child chunk with an
-`embedding` key and parent metadata, while the JSONL artifact omits embeddings
-to keep line-oriented inspection light. The worker requests provider-default
+`embedding` key. Parser chunks that have no type omit the `type` key instead of
+writing `type: null`. The worker requests provider-default
 Qwen3-Embedding-8B vectors, then locally truncates and normalizes them to the
 configured dimension:
 
@@ -193,7 +193,7 @@ For example, collection path `/course/thu_humanities` resolves raw files under
 
 The workers do not upload artifacts to S3 directly. The parse worker writes raw
 inputs and processed artifacts to NAS paths, including the manifest-declared
-JSONL, pickle, and optional full-text TXT artifacts, calls
+parser JSON, pickle, and optional full-text TXT artifacts, calls
 `complete_parse_local_ready_and_enqueue_s3_check(...)`, archives the parse queue
 message, and exits without waiting for NAS-to-S3 sync. The local-ready RPC and
 message archive, S3-ready completion RPC and message archive, and `fail_job_v2`

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Unstructure Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-17
-lastReviewedCommit: 1a689ec9260599e88a35283e614364c82de5e44f
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/artifacts.py
+++ b/src/kb_parse_worker/artifacts.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import shutil
 import uuid
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,17 @@ def _safe_replace_dir(src: Path, dst: Path) -> None:
         shutil.rmtree(backup)
 
 
+def _strip_null_type(value: Any) -> Any:
+    cleaned = deepcopy(value)
+    if isinstance(cleaned, dict) and cleaned.get("type") is None:
+        cleaned.pop("type", None)
+    return cleaned
+
+
+def _strip_null_type_list(items: list[Any]) -> list[Any]:
+    return [_strip_null_type(item) for item in items]
+
+
 def write_processed_artifacts(
     result: list[Any],
     snapshot: ParseSnapshot,
@@ -37,6 +49,9 @@ def write_processed_artifacts(
 ) -> tuple[Path, ArtifactInfo]:
     if not result:
         raise ValueError("EMPTY_RESULT")
+    result = _strip_null_type_list(result)
+    if parser_result is not None:
+        parser_result = _strip_null_type_list(parser_result)
 
     artifact_uuid = str(uuid.uuid4())
     collection_root = nas_processed_root / snapshot.processed_storage_path
@@ -46,7 +61,6 @@ def write_processed_artifacts(
         shutil.rmtree(tmp_dir)
     tmp_dir.mkdir(parents=True, exist_ok=False)
 
-    jsonl_path = tmp_dir / f"{artifact_uuid}.jsonl"
     pkl_path = tmp_dir / f"{artifact_uuid}.pkl"
     txt_path = tmp_dir / f"{artifact_uuid}.txt" if full_text is not None else None
     parser_json_path = tmp_dir / f"{artifact_uuid}.json" if parser_result is not None else None
@@ -55,23 +69,14 @@ def write_processed_artifacts(
             json.dumps(parser_result, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
             encoding="utf-8",
         )
-    with jsonl_path.open("w", encoding="utf-8") as handle:
-        for item in result:
-            if isinstance(item, dict) and "embedding" in item:
-                item = {key: value for key, value in item.items() if key != "embedding"}
-            handle.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
     with pkl_path.open("wb") as handle:
         pickle.dump(result, handle)
     if txt_path is not None:
         txt_path.write_text(full_text, encoding="utf-8")
 
-    with jsonl_path.open("r", encoding="utf-8") as handle:
-        jsonl_row_count = sum(1 for _ in handle)
-    if jsonl_row_count != len(result):
-        raise RuntimeError("ARTIFACT_VALIDATE_FAILED: jsonl row count mismatch")
     with pkl_path.open("rb") as handle:
         pickle.load(handle)
-    if jsonl_path.stat().st_size <= 0 or pkl_path.stat().st_size <= 0:
+    if pkl_path.stat().st_size <= 0:
         raise RuntimeError("ARTIFACT_VALIDATE_FAILED: empty artifact file")
     if parser_json_path is not None:
         parser_payload = json.loads(parser_json_path.read_text(encoding="utf-8"))
@@ -82,7 +87,6 @@ def write_processed_artifacts(
         snapshot=snapshot,
         artifact_uuid=artifact_uuid,
         chunk_count=len(result),
-        jsonl_path=jsonl_path,
         pkl_path=pkl_path,
         txt_path=txt_path,
         parser_json_path=parser_json_path,
@@ -98,15 +102,15 @@ def write_processed_artifacts(
     info = ArtifactInfo(
         artifact_uuid=artifact_uuid,
         chunk_count=len(result),
-        jsonl_name=jsonl_path.name,
+        jsonl_name=None,
         pkl_name=pkl_path.name,
         txt_name=txt_path.name if txt_path is not None else None,
         parser_json_name=parser_json_path.name if parser_json_path is not None else None,
-        jsonl_sha256=manifest["sha256"]["chunks_jsonl"],
+        jsonl_sha256=None,
         pkl_sha256=manifest["sha256"]["chunks_pkl"],
         txt_sha256=manifest["sha256"].get("full_text_txt"),
         parser_json_sha256=manifest["sha256"].get("parser_result_json"),
-        jsonl_size_bytes=manifest["size_bytes"]["chunks_jsonl"],
+        jsonl_size_bytes=None,
         pkl_size_bytes=manifest["size_bytes"]["chunks_pkl"],
         txt_size_bytes=manifest["size_bytes"].get("full_text_txt"),
         parser_json_size_bytes=manifest["size_bytes"].get("parser_result_json"),

--- a/src/kb_parse_worker/manifest.py
+++ b/src/kb_parse_worker/manifest.py
@@ -16,15 +16,15 @@ from .snapshot import ParseSnapshot
 class ArtifactInfo:
     artifact_uuid: str
     chunk_count: int
-    jsonl_name: str
+    jsonl_name: str | None
     pkl_name: str
     txt_name: str | None
     parser_json_name: str | None
-    jsonl_sha256: str
+    jsonl_sha256: str | None
     pkl_sha256: str
     txt_sha256: str | None
     parser_json_sha256: str | None
-    jsonl_size_bytes: int
+    jsonl_size_bytes: int | None
     pkl_size_bytes: int
     txt_size_bytes: int | None
     parser_json_size_bytes: int | None
@@ -44,7 +44,6 @@ def build_manifest(
     snapshot: ParseSnapshot,
     artifact_uuid: str,
     chunk_count: int,
-    jsonl_path: Path,
     pkl_path: Path,
     txt_path: Path | None,
     parser_json_path: Path | None,
@@ -52,18 +51,14 @@ def build_manifest(
     parser_version: str,
     embedding: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], str]:
-    jsonl_name = jsonl_path.name
     pkl_name = pkl_path.name
     artifacts = {
-        "chunks_jsonl": jsonl_name,
         "chunks_pkl": pkl_name,
     }
     sha256 = {
-        "chunks_jsonl": file_sha256(jsonl_path),
         "chunks_pkl": file_sha256(pkl_path),
     }
     size_bytes = {
-        "chunks_jsonl": jsonl_path.stat().st_size,
         "chunks_pkl": pkl_path.stat().st_size,
     }
     if txt_path is not None:
@@ -113,19 +108,21 @@ def load_artifact_info(manifest_path: Path, manifest_hash: str | None = None) ->
     return ArtifactInfo(
         artifact_uuid=str(manifest["artifact_uuid"]),
         chunk_count=int(manifest["chunk_count"]),
-        jsonl_name=str(artifacts["chunks_jsonl"]),
+        jsonl_name=str(artifacts["chunks_jsonl"]) if artifacts.get("chunks_jsonl") else None,
         pkl_name=str(artifacts["chunks_pkl"]),
         txt_name=str(artifacts["full_text_txt"]) if artifacts.get("full_text_txt") else None,
         parser_json_name=(
             str(artifacts["parser_result_json"]) if artifacts.get("parser_result_json") else None
         ),
-        jsonl_sha256=str(sha256["chunks_jsonl"]),
+        jsonl_sha256=str(sha256["chunks_jsonl"]) if sha256.get("chunks_jsonl") else None,
         pkl_sha256=str(sha256["chunks_pkl"]),
         txt_sha256=str(sha256["full_text_txt"]) if sha256.get("full_text_txt") else None,
         parser_json_sha256=(
             str(sha256["parser_result_json"]) if sha256.get("parser_result_json") else None
         ),
-        jsonl_size_bytes=int(size_bytes["chunks_jsonl"]),
+        jsonl_size_bytes=(
+            int(size_bytes["chunks_jsonl"]) if size_bytes.get("chunks_jsonl") is not None else None
+        ),
         pkl_size_bytes=int(size_bytes["chunks_pkl"]),
         txt_size_bytes=int(size_bytes["full_text_txt"]) if size_bytes.get("full_text_txt") is not None else None,
         parser_json_size_bytes=(

--- a/tests/test_kb_parse_worker_artifacts.py
+++ b/tests/test_kb_parse_worker_artifacts.py
@@ -199,12 +199,12 @@ class KbParseWorkerArtifactTests(unittest.TestCase):
             self.assertEqual(manifest["size_bytes"]["full_text_txt"], len("whole document text"))
 
     def test_write_processed_artifacts_writes_parser_result_json(self) -> None:
-        parser_result = [{"text": "raw chunk", "page_number": 1}]
+        parser_result = [{"text": "raw chunk", "page_number": 1, "type": None}]
         embedded_result = [
             {
                 "text": "raw chunk",
                 "page_number": 1,
-                "type": "text",
+                "type": None,
                 "embedding": [0.1, 0.2],
             }
         ]
@@ -224,10 +224,18 @@ class KbParseWorkerArtifactTests(unittest.TestCase):
             parser_json_name = manifest["artifacts"]["parser_result_json"]
 
             self.assertEqual(parser_json_name, f"{manifest['artifact_uuid']}.json")
+            self.assertNotIn("chunks_jsonl", manifest["artifacts"])
+            self.assertFalse(list(final_dir.glob("*.jsonl")))
             self.assertEqual(
                 json.loads((final_dir / parser_json_name).read_text(encoding="utf-8")),
-                parser_result,
+                [{"text": "raw chunk", "page_number": 1}],
             )
+            pkl_name = manifest["artifacts"]["chunks_pkl"]
+            import pickle
+
+            with (final_dir / pkl_name).open("rb") as handle:
+                pkl_payload = pickle.load(handle)
+            self.assertNotIn("type", pkl_payload[0])
             self.assertEqual(artifact_info.parser_json_name, parser_json_name)
 
 


### PR DESCRIPTION
## Summary

- stop writing KB parse chunk JSONL artifacts for new processed outputs
- keep parser JSON and embedded pickle artifacts, with backward-compatible manifest loading for old JSONL manifests
- strip `type: null` from parser JSON and pickle payloads when parser chunks have no type
- update worker artifact tests and docs to match the new artifact contract

## Validation

- `uv run --with requests --with tiktoken python -m unittest tests.test_kb_parse_worker_chunk_splitter tests.test_kb_parse_worker_artifacts`
- `python3 -m compileall src/kb_parse_worker`
- `git diff --check -- _docs/architecture/repo-architecture.md _docs/runbooks/development.md src/kb_parse_worker/artifacts.py src/kb_parse_worker/manifest.py tests/test_kb_parse_worker_artifacts.py`
- `docpact lint --root . --base origin/main --head HEAD` reported 9 missing-review warnings for governance docs; coverage/freshness were ok.

Related to #30.
