### PR TITLE
feat(kb): split two-stage parse submitter and finalizer

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "eda42e5c0a485212b71a8aefc808574fa0bf013a"
+lastReviewedAt: "2026-05-21"
+lastReviewedCommit: "2a94026defb263f98b423e2cdfceb1229f4c461b"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -33,7 +33,14 @@ Workflows are organized by source domain under `src/**`.
   `/mineru_with_images` endpoint or, when `KB_PARSE_USE_TWO_STAGE=true`,
   submits `/two_stage/task` and polls `/two_stage/task/{task_id}` for the same
   `result`/`txt` payload contract. It publishes processed artifacts to NAS and
-  enqueues the S3-ready check. The S3-ready worker consumes
+  enqueues the S3-ready check. For deployments that want Unstructure-Serve's
+  Celery queue to hold parse backlog, the worker also supports split
+  `parse-submitter` and `parse-finalizer` modes: the submitter applies
+  `/two_stage/queue_status` backpressure, submits `/two_stage/task`, persists
+  the returned task id in the KB job payload, and archives the parse PGMQ
+  message; the finalizer claims those persisted task ids, polls task status,
+  writes processed artifacts, and completes the parse handoff. The S3-ready
+  worker consumes
   `kb_s3_ready_queue` and marks processed artifacts ready after S3 verification.
 - `ecosystem.kb_parse_worker.json`: PM2 process definitions for the KB parse
   worker and S3-ready worker.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -51,6 +51,8 @@ Run one queue message:
 
 ```bash
 python -m src.kb_parse_worker.cli once
+python -m src.kb_parse_worker.cli once --worker parse-submitter
+python -m src.kb_parse_worker.cli once --worker parse-finalizer
 python -m src.kb_parse_worker.cli once --worker s3-ready
 python -m src.kb_parse_worker.cli once --worker parse-finalization-reconciler --dry-run
 python -m src.kb_parse_worker.cli once --worker parse-finalization-reconciler
@@ -60,6 +62,8 @@ Run continuously:
 
 ```bash
 python -m src.kb_parse_worker.cli run
+python -m src.kb_parse_worker.cli run --worker parse-submitter
+python -m src.kb_parse_worker.cli run --worker parse-finalizer
 python -m src.kb_parse_worker.cli run --worker s3-ready
 python -m src.kb_parse_worker.cli run --worker parse-finalization-reconciler
 ```
@@ -68,15 +72,24 @@ Run continuously under PM2:
 
 ```bash
 pm2 start ecosystem.kb_parse_worker.json
+pm2 start ecosystem.kb_parse_worker.two_stage_async.json
 pm2 save
 pm2 resurrect
 pm2 logs kb-parse-worker
+pm2 logs kb-parse-submitter
+pm2 logs kb-parse-finalizer
 pm2 logs kb-s3-ready-worker
 pm2 restart kb-parse-worker
+pm2 restart kb-parse-submitter
+pm2 restart kb-parse-finalizer
 pm2 restart kb-s3-ready-worker
 pm2 stop kb-parse-worker
+pm2 stop kb-parse-submitter
+pm2 stop kb-parse-finalizer
 pm2 stop kb-s3-ready-worker
 pm2 delete kb-parse-worker
+pm2 delete kb-parse-submitter
+pm2 delete kb-parse-finalizer
 pm2 delete kb-s3-ready-worker
 ```
 
@@ -142,6 +155,36 @@ or `/two_stage/task`. `UNSTRUCTURE_SERVE_BEARER_TOKEN` is reused for both
 submit and status polling. Optional `KB_PARSE_TWO_STAGE_PROVIDER`,
 `KB_PARSE_TWO_STAGE_MODEL`, and `KB_PARSE_TWO_STAGE_PROMPT` can override the
 parser-side vision defaults; leave them unset for normal deployment.
+
+The default `parse` worker keeps the historical synchronous behavior: it submits
+one `/two_stage/task`, polls it to completion, writes processed artifacts, and
+then claims the next KB parse job. To let Unstructure-Serve's Celery queues hold
+a controlled parse backlog instead, run the split async modes:
+
+```text
+KB_PARSE_USE_TWO_STAGE=true
+KB_PARSE_TWO_STAGE_PARSE_QUEUE=queue_parse_gpu
+KB_PARSE_TWO_STAGE_MAX_PARSE_BACKLOG=5
+KB_PARSE_TWO_STAGE_QUEUE_STATUS_TIMEOUT_SECONDS=10
+KB_PARSE_TWO_STAGE_FINALIZER_LIMIT=1
+```
+
+For PM2 deployment of the split mode, stop or delete the historical
+`kb-parse-worker` process first, then start
+`ecosystem.kb_parse_worker.two_stage_async.json`. Keep `kb-s3-ready-worker`
+running from `ecosystem.kb_parse_worker.json`; do not run the historical
+`kb-parse-worker` and split submitter/finalizer against the same parse queue at
+the same time.
+
+`parse-submitter` calls `/two_stage/queue_status` and submits another KB parse
+job only when `queues[KB_PARSE_TWO_STAGE_PARSE_QUEUE] +
+unacked[KB_PARSE_TWO_STAGE_PARSE_QUEUE]` is below
+`KB_PARSE_TWO_STAGE_MAX_PARSE_BACKLOG`. It persists the returned Celery
+`task_id` in `kb_jobs.payload_json.two_stage` through the KB control-plane RPC
+and archives the original parse PGMQ message. `parse-finalizer` claims those
+persisted task ids, polls `/two_stage/task/{task_id}`, extends short polling
+locks for pending tasks, and performs the existing processed-artifact and
+`s3_ready` handoff when a task succeeds.
 
 Both modes request `return_txt=true`. The worker uses the returned `result` JSON
 for chunk embeddings and pickle generation, drops any returned chunk whose

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # Unstructure Documentation Standards

--- a/ecosystem.kb_parse_worker.two_stage_async.json
+++ b/ecosystem.kb_parse_worker.two_stage_async.json
@@ -1,0 +1,42 @@
+{
+  "apps": [
+    {
+      "name": "kb-parse-submitter",
+      "cwd": ".",
+      "script": ".venv/bin/python",
+      "interpreter": "none",
+      "args": "-m src.kb_parse_worker.cli run --worker parse-submitter --log-level INFO",
+      "watch": false,
+      "autorestart": true,
+      "max_restarts": 10,
+      "env": {
+        "PYTHONUNBUFFERED": "1",
+        "KB_PARSE_USE_TWO_STAGE": "true",
+        "KB_PARSE_TWO_STAGE_PARSE_QUEUE": "queue_parse_gpu",
+        "KB_PARSE_TWO_STAGE_MAX_PARSE_BACKLOG": "5"
+      },
+      "out_file": "logs/kb-parse-submitter.out.log",
+      "error_file": "logs/kb-parse-submitter.err.log",
+      "merge_logs": true,
+      "time": true
+    },
+    {
+      "name": "kb-parse-finalizer",
+      "cwd": ".",
+      "script": ".venv/bin/python",
+      "interpreter": "none",
+      "args": "-m src.kb_parse_worker.cli run --worker parse-finalizer --log-level INFO",
+      "watch": false,
+      "autorestart": true,
+      "max_restarts": 10,
+      "env": {
+        "PYTHONUNBUFFERED": "1",
+        "KB_PARSE_USE_TWO_STAGE": "true"
+      },
+      "out_file": "logs/kb-parse-finalizer.out.log",
+      "error_file": "logs/kb-parse-finalizer.err.log",
+      "merge_logs": true,
+      "time": true
+    }
+  ]
+}

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/cli.py
+++ b/src/kb_parse_worker/cli.py
@@ -7,7 +7,7 @@ import logging
 
 from .config import WorkerConfig
 from .reconciler import ParseFinalizationReconciler
-from .worker import ParseWorker, S3ReadyWorker
+from .worker import ParseFinalizerWorker, ParseSubmitterWorker, ParseWorker, S3ReadyWorker
 
 
 def main() -> int:
@@ -15,7 +15,13 @@ def main() -> int:
     parser.add_argument("mode", choices=("once", "run"), help="Run one queue message or poll forever.")
     parser.add_argument(
         "--worker",
-        choices=("parse", "s3-ready", "parse-finalization-reconciler"),
+        choices=(
+            "parse",
+            "parse-submitter",
+            "parse-finalizer",
+            "s3-ready",
+            "parse-finalization-reconciler",
+        ),
         default="parse",
         help="Worker role to run.",
     )
@@ -45,6 +51,10 @@ def main() -> int:
     config = WorkerConfig.from_env()
     if args.worker == "parse":
         worker = ParseWorker(config)
+    elif args.worker == "parse-submitter":
+        worker = ParseSubmitterWorker(config)
+    elif args.worker == "parse-finalizer":
+        worker = ParseFinalizerWorker(config)
     elif args.worker == "s3-ready":
         worker = S3ReadyWorker(config)
     else:

--- a/src/kb_parse_worker/config.py
+++ b/src/kb_parse_worker/config.py
@@ -104,6 +104,10 @@ class WorkerConfig:
     two_stage_provider: str | None
     two_stage_model: str | None
     two_stage_prompt: str | None
+    two_stage_parse_queue_name: str
+    two_stage_max_parse_backlog: int
+    two_stage_queue_status_timeout_seconds: int
+    two_stage_finalizer_limit: int
     parser_profile: str
     parser_version: str
     s3_ready_mode: str
@@ -172,6 +176,17 @@ class WorkerConfig:
             two_stage_provider=_optional_str_env("KB_PARSE_TWO_STAGE_PROVIDER"),
             two_stage_model=_optional_str_env("KB_PARSE_TWO_STAGE_MODEL"),
             two_stage_prompt=_optional_str_env("KB_PARSE_TWO_STAGE_PROMPT"),
+            two_stage_parse_queue_name=os.getenv(
+                "KB_PARSE_TWO_STAGE_PARSE_QUEUE",
+                "queue_parse_gpu",
+            ),
+            two_stage_max_parse_backlog=_int_env("KB_PARSE_TWO_STAGE_MAX_PARSE_BACKLOG", 5),
+            two_stage_queue_status_timeout_seconds=_positive_int_env(
+                "KB_PARSE_TWO_STAGE_QUEUE_STATUS_TIMEOUT_SECONDS", 10
+            ),
+            two_stage_finalizer_limit=_positive_int_env(
+                "KB_PARSE_TWO_STAGE_FINALIZER_LIMIT", 1
+            ),
             parser_profile=os.getenv("KB_PARSE_PARSER_PROFILE", "mineru_with_images"),
             parser_version=os.getenv("KB_PARSE_PARSER_VERSION", "unstructure-serve"),
             s3_ready_mode=os.getenv("KB_PARSE_S3_READY_MODE", "check"),

--- a/src/kb_parse_worker/control_plane.py
+++ b/src/kb_parse_worker/control_plane.py
@@ -54,6 +54,28 @@ class FailJobResult:
     retry_wakeup_msg_id: int | None = None
 
 
+@dataclass(frozen=True)
+class TwoStageRegistrationResult:
+    job_id: str
+    document_id: str
+    document_version: int
+    task_id: str
+    document_status: str
+
+
+@dataclass(frozen=True)
+class TwoStageFinalizationClaim:
+    job_id: str
+    document_id: str
+    document_version: int
+    task_id: str
+    task_url: str | None
+    status_url: str | None
+    state: str | None
+    submitted_at: str | None
+    payload_json: dict
+
+
 def connect(database_url: str):
     return psycopg2.connect(database_url)
 
@@ -137,6 +159,99 @@ def fail_job(
             int(row["retry_wakeup_msg_id"]) if row["retry_wakeup_msg_id"] is not None else None
         ),
     )
+
+
+def register_parse_two_stage_task(
+    conn,
+    job_id: str,
+    worker_id: str,
+    task_id: str,
+    task_url: str,
+    status_url: str,
+    queue_name: str,
+    msg_id: int,
+    lock_seconds: int,
+    backlog_json: dict,
+) -> TwoStageRegistrationResult | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select *
+            from public.register_parse_two_stage_task(
+              %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                job_id,
+                worker_id,
+                task_id,
+                task_url,
+                status_url,
+                queue_name,
+                msg_id,
+                lock_seconds,
+                psycopg2.extras.Json(backlog_json),
+            ),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    return TwoStageRegistrationResult(
+        job_id=str(row["job_id"]),
+        document_id=str(row["document_id"]),
+        document_version=int(row["document_version"]),
+        task_id=str(row["task_id"]),
+        document_status=str(row["document_status"]),
+    )
+
+
+def claim_parse_two_stage_task(
+    conn,
+    worker_id: str,
+    lock_seconds: int,
+) -> TwoStageFinalizationClaim | None:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            select *
+            from public.claim_parse_two_stage_task(%s, %s)
+            """,
+            (worker_id, lock_seconds),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    return TwoStageFinalizationClaim(
+        job_id=str(row["job_id"]),
+        document_id=str(row["document_id"]),
+        document_version=int(row["document_version"]),
+        task_id=str(row["task_id"]),
+        task_url=str(row["task_url"]) if row["task_url"] is not None else None,
+        status_url=str(row["status_url"]) if row["status_url"] is not None else None,
+        state=str(row["state"]) if row["state"] is not None else None,
+        submitted_at=row["submitted_at"].isoformat() if row["submitted_at"] is not None else None,
+        payload_json=dict(row["payload_json"] or {}),
+    )
+
+
+def mark_parse_two_stage_task_state(
+    conn,
+    job_id: str,
+    worker_id: str,
+    state: str,
+    error: str | None,
+    lock_seconds: int,
+) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            "select public.mark_parse_two_stage_task_state(%s, %s, %s, %s, %s)",
+            (job_id, worker_id, state, error[:2000] if error is not None else None, lock_seconds),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return bool(row and row[0])
 
 
 def mark_parse_local_ready(

--- a/src/kb_parse_worker/parser_adapter.py
+++ b/src/kb_parse_worker/parser_adapter.py
@@ -30,6 +30,31 @@ class ParsedDocument:
     dropped_empty_text_count: int
 
 
+@dataclass(frozen=True)
+class TwoStageTaskSubmission:
+    task_id: str
+    state: str | None
+    task_url: str
+    status_url: str
+
+
+@dataclass(frozen=True)
+class TwoStageTaskStatus:
+    task_id: str
+    state: str
+    parsed: ParsedDocument | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class TwoStageQueueStatus:
+    queues: dict[str, int]
+    unacked: dict[str, int]
+
+    def backlog(self, queue_name: str) -> int:
+        return int(self.queues.get(queue_name, 0)) + int(self.unacked.get(queue_name, 0))
+
+
 def _has_nonempty_text(item: Any) -> bool:
     if isinstance(item, dict):
         text = item.get("text")
@@ -80,6 +105,111 @@ def _raise_for_parser_status(response: requests.Response) -> None:
         raise ParserError(f"parser http error {response.status_code}: {response.text[:500]}") from exc
 
 
+def submit_two_stage_task(
+    raw_path: Path,
+    base_url: str,
+    bearer_token: str,
+    *,
+    timeout_seconds: int,
+    return_txt: bool,
+    priority: str,
+    chunk_type: bool,
+    provider: str | None,
+    model: str | None,
+    prompt: str | None,
+) -> TwoStageTaskSubmission:
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    submit_url = f"{base_url.rstrip('/')}/two_stage/task"
+    form_data: dict[str, str] = {
+        "return_txt": "true" if return_txt else "false",
+        "chunk_type": "true" if chunk_type else "false",
+        "priority": priority or "normal",
+    }
+    if provider:
+        form_data["provider"] = provider
+    if model:
+        form_data["model"] = model
+    if prompt:
+        form_data["prompt"] = prompt
+
+    with raw_path.open("rb") as handle:
+        response = requests.post(
+            submit_url,
+            files={"file": (raw_path.name, handle)},
+            data=form_data,
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+    _raise_for_parser_status(response)
+    payload = response.json()
+    task_id = payload.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        raise ParserError("parser response missing task_id")
+    return TwoStageTaskSubmission(
+        task_id=task_id,
+        state=payload.get("state") if isinstance(payload.get("state"), str) else None,
+        task_url=submit_url,
+        status_url=f"{submit_url}/{task_id}",
+    )
+
+
+def fetch_two_stage_task_status(
+    base_url: str,
+    bearer_token: str,
+    task_id: str,
+    *,
+    timeout_seconds: int,
+    return_txt: bool,
+) -> TwoStageTaskStatus:
+    status_url = f"{base_url.rstrip('/')}/two_stage/task/{task_id}"
+    response = requests.get(
+        status_url,
+        headers={"Authorization": f"Bearer {bearer_token}"},
+        timeout=timeout_seconds,
+    )
+    _raise_for_parser_status(response)
+    payload = response.json()
+    state = payload.get("state")
+    if not isinstance(state, str) or not state:
+        raise ParserError("parser response missing state")
+    if state == "SUCCESS":
+        result_payload = payload.get("result")
+        if not isinstance(result_payload, dict):
+            raise ParserError("parser response missing result payload")
+        return TwoStageTaskStatus(
+            task_id=task_id,
+            state=state,
+            parsed=_parsed_document_from_payload(result_payload, return_txt),
+        )
+    if state in {"FAILURE", "REVOKED"}:
+        error = payload.get("error") or state
+        return TwoStageTaskStatus(task_id=task_id, state=state, error=str(error))
+    return TwoStageTaskStatus(task_id=task_id, state=state)
+
+
+def fetch_two_stage_queue_status(
+    base_url: str,
+    bearer_token: str,
+    *,
+    timeout_seconds: int,
+) -> TwoStageQueueStatus:
+    response = requests.get(
+        f"{base_url.rstrip('/')}/two_stage/queue_status",
+        headers={"Authorization": f"Bearer {bearer_token}"},
+        timeout=timeout_seconds,
+    )
+    _raise_for_parser_status(response)
+    payload = response.json()
+    queues = payload.get("queues")
+    unacked = payload.get("unacked")
+    if not isinstance(queues, dict) or not isinstance(unacked, dict):
+        raise ParserError("parser queue status response missing queues/unacked")
+    return TwoStageQueueStatus(
+        queues={str(key): int(value) for key, value in queues.items()},
+        unacked={str(key): int(value) for key, value in unacked.items()},
+    )
+
+
 def _parse_with_two_stage(
     raw_path: Path,
     base_url: str,
@@ -99,57 +229,39 @@ def _parse_with_two_stage(
     if timeout_seconds <= 0:
         raise ParserTimeout("parser two-stage timeout before submit")
     deadline = time.monotonic() + timeout_seconds
-    headers = {"Authorization": f"Bearer {bearer_token}"}
-    submit_url = f"{base_url.rstrip('/')}/two_stage/task"
-    status_base_url = submit_url
-    form_data: dict[str, str] = {
-        "return_txt": "true" if return_txt else "false",
-        "chunk_type": "true" if chunk_type else "false",
-        "priority": priority or "normal",
-    }
-    if provider:
-        form_data["provider"] = provider
-    if model:
-        form_data["model"] = model
-    if prompt:
-        form_data["prompt"] = prompt
-
-    with raw_path.open("rb") as handle:
-        response = requests.post(
-            submit_url,
-            files={"file": (raw_path.name, handle)},
-            data=form_data,
-            headers=headers,
-            timeout=min(submit_timeout_seconds, max(1, int(deadline - time.monotonic()))),
-        )
-    _raise_for_parser_status(response)
-    submit_payload = response.json()
-    task_id = submit_payload.get("task_id")
-    if not isinstance(task_id, str) or not task_id:
-        raise ParserError("parser response missing task_id")
+    submission = submit_two_stage_task(
+        raw_path,
+        base_url,
+        bearer_token,
+        timeout_seconds=min(submit_timeout_seconds, max(1, int(deadline - time.monotonic()))),
+        return_txt=return_txt,
+        priority=priority,
+        chunk_type=chunk_type,
+        provider=provider,
+        model=model,
+        prompt=prompt,
+    )
 
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise ParserTimeout(f"parser two-stage task {task_id} timed out")
-        status_response = requests.get(
-            f"{status_base_url}/{task_id}",
-            headers=headers,
-            timeout=min(status_timeout_seconds, max(1, int(remaining))),
+            raise ParserTimeout(f"parser two-stage task {submission.task_id} timed out")
+        status = fetch_two_stage_task_status(
+            base_url,
+            bearer_token,
+            submission.task_id,
+            timeout_seconds=min(status_timeout_seconds, max(1, int(remaining))),
+            return_txt=return_txt,
         )
-        _raise_for_parser_status(status_response)
-        status_payload = status_response.json()
-        state = status_payload.get("state")
-        if state == "SUCCESS":
-            result_payload = status_payload.get("result")
-            if not isinstance(result_payload, dict):
+        if status.state == "SUCCESS":
+            if status.parsed is None:
                 raise ParserError("parser response missing result payload")
-            return _parsed_document_from_payload(result_payload, return_txt)
-        if state in {"FAILURE", "REVOKED"}:
-            error_detail = status_payload.get("error") or state
-            raise ParserTaskFailure(f"parser two-stage task {task_id} failed: {error_detail}")
-        if not isinstance(state, str) or not state:
-            raise ParserError("parser response missing state")
+            return status.parsed
+        if status.state in {"FAILURE", "REVOKED"}:
+            error_detail = status.error or status.state
+            raise ParserTaskFailure(
+                f"parser two-stage task {submission.task_id} failed: {error_detail}"
+            )
         time.sleep(min(poll_interval_seconds, max(0.1, deadline - time.monotonic())))
 
 

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -21,7 +21,10 @@ from .parser_adapter import (
     ParserError,
     ParserTaskFailure,
     ParserTimeout,
+    fetch_two_stage_queue_status,
+    fetch_two_stage_task_status,
     parse_with_unstructure_serve,
+    submit_two_stage_task,
 )
 from .s3_ready import processed_manifest_key, wait_for_s3_processed_ready
 from .snapshot import (
@@ -230,6 +233,107 @@ def complete_parse_local_ready_and_archive_with_retry(
     raise RuntimeError("parse finalization retry loop exhausted")
 
 
+def complete_parse_local_ready_with_retry(
+    config: WorkerConfig,
+    job_id: str,
+    document_id: str,
+    document_version: int,
+    manifest_local_uri: str,
+    artifact_uuid: str,
+    manifest_hash: str,
+    chunk_count: int,
+    metadata_json: dict,
+    s3_ready_payload_json: dict,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
+) -> control_plane.S3ReadyEnqueueResult:
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with control_plane.connect(config.database_url) as active_conn:
+                result = control_plane.complete_parse_local_ready_and_enqueue_s3_check(
+                    active_conn,
+                    job_id,
+                    config.worker_id,
+                    document_id,
+                    document_version,
+                    manifest_local_uri,
+                    artifact_uuid,
+                    manifest_hash,
+                    chunk_count,
+                    metadata_json,
+                    s3_ready_payload_json,
+                )
+                if result is None:
+                    raise RuntimeError(
+                        "complete_parse_local_ready_and_enqueue_s3_check returned no row"
+                    )
+                return result
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "parse job %s async finalization DB write failed on attempt %s/%s; "
+                "reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("parse async finalization retry loop exhausted")
+
+
+def register_parse_two_stage_task_and_archive_with_retry(
+    config: WorkerConfig,
+    job_id: str,
+    task_id: str,
+    task_url: str,
+    status_url: str,
+    queue_name: str,
+    msg_id: int,
+    backlog_json: dict,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
+) -> control_plane.TwoStageRegistrationResult:
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with control_plane.connect(config.database_url) as active_conn:
+                result = control_plane.register_parse_two_stage_task(
+                    active_conn,
+                    job_id,
+                    config.worker_id,
+                    task_id,
+                    task_url,
+                    status_url,
+                    queue_name,
+                    msg_id,
+                    config.lock_seconds,
+                    backlog_json,
+                )
+                if result is None:
+                    raise RuntimeError("register_parse_two_stage_task returned no row")
+                return result
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "parse job %s two-stage registration DB write failed on attempt %s/%s; "
+                "reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("two-stage registration retry loop exhausted")
+
+
 def handle_unclaimed_message(
     conn,
     queue_name: str,
@@ -286,6 +390,54 @@ def fail_job_and_archive_current_message(
                         result.retry_wakeup_msg_id,
                     )
                     archive_current_message(active_conn, queue_name, msg_id)
+                return result
+        except Exception as exc:
+            if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
+                raise
+            LOGGER.warning(
+                "job %s fail_job DB write failed on attempt %s/%s; reconnecting before retry",
+                job_id,
+                attempt,
+                max_attempts,
+                exc_info=True,
+            )
+            time.sleep(_finalization_backoff_seconds(attempt))
+
+    raise RuntimeError("fail_job retry loop exhausted")
+
+
+def fail_job_with_retry(
+    config: WorkerConfig,
+    job_id: str,
+    worker_id: str,
+    retryable: bool,
+    error: str,
+    error_stage: str,
+    max_attempts: int = FINALIZE_DB_MAX_ATTEMPTS,
+) -> control_plane.FailJobResult | None:
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be positive")
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with control_plane.connect(config.database_url) as active_conn:
+                result = control_plane.fail_job(
+                    active_conn,
+                    job_id,
+                    worker_id,
+                    retryable,
+                    error,
+                    error_stage,
+                )
+                if result is not None:
+                    LOGGER.info(
+                        "job %s failed status=%s retryable=%s next_retry_at=%s retry_wakeup_msg_id=%s",
+                        job_id,
+                        result.job_status,
+                        retryable,
+                        result.next_retry_at,
+                        result.retry_wakeup_msg_id,
+                    )
                 return result
         except Exception as exc:
             if not _is_retryable_finalization_error(exc) or attempt >= max_attempts:
@@ -369,6 +521,111 @@ def _validate_raw_file(path: Path, expected_size: int | None, expected_sha256: s
         raise RuntimeError("RAW_SIZE_MISMATCH")
     if _sha256(path).lower() != expected_sha256.lower():
         raise RuntimeError("RAW_HASH_MISMATCH")
+
+
+def build_s3_ready_payload(config: WorkerConfig, snapshot) -> dict:
+    return {
+        "collection_path": snapshot.collection_path,
+        "collection_storage_path": snapshot.collection_storage_path,
+        "processed_storage_path": snapshot.processed_storage_path,
+        "manifest_s3_key": processed_manifest_key(
+            config.s3_processed_prefix,
+            snapshot,
+        ),
+        "s3_bucket": config.s3_bucket,
+        "s3_prefix": config.s3_processed_prefix,
+    }
+
+
+def write_processed_artifacts_from_parsed(
+    config: WorkerConfig,
+    job_id: str,
+    snapshot,
+    parsed,
+    deadline: JobDeadline,
+    lease=None,
+) -> tuple[str, object, dict]:
+    result = parsed.result
+    if parsed.dropped_empty_text_count:
+        LOGGER.info(
+            "parse job %s dropped %s empty text chunk(s) from %s parser chunk(s)",
+            job_id,
+            parsed.dropped_empty_text_count,
+            parsed.original_chunk_count,
+        )
+    if lease is not None:
+        lease.check()
+    deadline.check()
+
+    embedding_chunks, split_stats = split_chunks_for_embedding(
+        result,
+        snapshot.document_id,
+        config.embedding_chunk_max_tokens,
+    )
+    if split_stats.split_parent_count:
+        LOGGER.info(
+            "parse job %s split %s/%s parser chunk(s) into %s embedding chunk(s)",
+            job_id,
+            split_stats.split_parent_count,
+            split_stats.source_chunk_count,
+            split_stats.output_chunk_count,
+        )
+    if lease is not None:
+        lease.check()
+    deadline.check()
+
+    embedded_result = add_chunk_embeddings(
+        embedding_chunks,
+        config.embedding_base_url,
+        config.embedding_model,
+        config.embedding_api_key,
+        config.embedding_dimensions,
+        config.embedding_batch_size,
+        deadline.remaining_seconds(config.embedding_timeout_seconds),
+        deadline.check,
+    )
+    if lease is not None:
+        lease.check()
+    deadline.check()
+
+    embedding_metadata = {
+        "model": config.embedding_model,
+        "base_url": config.embedding_base_url,
+        "dimensions": config.embedding_dimensions,
+        "normalized": True,
+        "source_dimensions": "provider_default",
+        "chunk_max_tokens": config.embedding_chunk_max_tokens,
+        "source_chunk_count": split_stats.source_chunk_count,
+        "embedding_chunk_count": split_stats.output_chunk_count,
+        "split_parent_count": split_stats.split_parent_count,
+    }
+    final_dir, artifact_info = write_processed_artifacts(
+        embedded_result,
+        snapshot,
+        config.nas_processed_root,
+        config.parser_profile,
+        config.parser_version,
+        embedding_metadata,
+        parsed.txt,
+        result,
+    )
+    if lease is not None:
+        lease.check()
+    deadline.check()
+
+    manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
+    metadata_json = {
+        "processed": {
+            "parser_profile": config.parser_profile,
+            "parser_version": config.parser_version,
+            "chunk_count": artifact_info.chunk_count,
+            "artifact_uuid": artifact_info.artifact_uuid,
+            "source_chunk_count": parsed.original_chunk_count,
+            "dropped_empty_text_count": parsed.dropped_empty_text_count,
+            "embedding": embedding_metadata,
+        }
+    }
+    return manifest_local_uri, artifact_info, metadata_json
 
 
 class LeaseMaintainer:
@@ -510,94 +767,18 @@ class ParseWorker:
                         two_stage_model=self.config.two_stage_model,
                         two_stage_prompt=self.config.two_stage_prompt,
                     )
-                    result = parsed.result
-                    if parsed.dropped_empty_text_count:
-                        LOGGER.info(
-                            "parse job %s dropped %s empty text chunk(s) from %s parser chunk(s)",
+                    manifest_local_uri, artifact_info, metadata_json = (
+                        write_processed_artifacts_from_parsed(
+                            self.config,
                             claimed.job_id,
-                            parsed.dropped_empty_text_count,
-                            parsed.original_chunk_count,
+                            snapshot,
+                            parsed,
+                            deadline,
+                            lease,
                         )
-                    lease.check()
-                    deadline.check()
-
-                    embedding_chunks, split_stats = split_chunks_for_embedding(
-                        result,
-                        snapshot.document_id,
-                        self.config.embedding_chunk_max_tokens,
                     )
-                    if split_stats.split_parent_count:
-                        LOGGER.info(
-                            "parse job %s split %s/%s parser chunk(s) into %s embedding chunk(s)",
-                            claimed.job_id,
-                            split_stats.split_parent_count,
-                            split_stats.source_chunk_count,
-                            split_stats.output_chunk_count,
-                        )
-                    lease.check()
-                    deadline.check()
 
-                    embedded_result = add_chunk_embeddings(
-                        embedding_chunks,
-                        self.config.embedding_base_url,
-                        self.config.embedding_model,
-                        self.config.embedding_api_key,
-                        self.config.embedding_dimensions,
-                        self.config.embedding_batch_size,
-                        deadline.remaining_seconds(self.config.embedding_timeout_seconds),
-                        deadline.check,
-                    )
-                    lease.check()
-                    deadline.check()
-
-                    embedding_metadata = {
-                        "model": self.config.embedding_model,
-                        "base_url": self.config.embedding_base_url,
-                        "dimensions": self.config.embedding_dimensions,
-                        "normalized": True,
-                        "source_dimensions": "provider_default",
-                        "chunk_max_tokens": self.config.embedding_chunk_max_tokens,
-                        "source_chunk_count": split_stats.source_chunk_count,
-                        "embedding_chunk_count": split_stats.output_chunk_count,
-                        "split_parent_count": split_stats.split_parent_count,
-                    }
-                    final_dir, artifact_info = write_processed_artifacts(
-                        embedded_result,
-                        snapshot,
-                        self.config.nas_processed_root,
-                        self.config.parser_profile,
-                        self.config.parser_version,
-                        embedding_metadata,
-                        parsed.txt,
-                        result,
-                    )
-                    lease.check()
-                    deadline.check()
-
-                    manifest_local_uri = final_dir.joinpath("manifest.json").as_posix()
-                    metadata_json = {
-                        "processed": {
-                            "parser_profile": self.config.parser_profile,
-                            "parser_version": self.config.parser_version,
-                            "chunk_count": artifact_info.chunk_count,
-                            "artifact_uuid": artifact_info.artifact_uuid,
-                            "source_chunk_count": parsed.original_chunk_count,
-                            "dropped_empty_text_count": parsed.dropped_empty_text_count,
-                            "embedding": embedding_metadata,
-                        }
-                    }
-
-                s3_ready_payload_json = {
-                    "collection_path": snapshot.collection_path,
-                    "collection_storage_path": snapshot.collection_storage_path,
-                    "processed_storage_path": snapshot.processed_storage_path,
-                    "manifest_s3_key": processed_manifest_key(
-                        self.config.s3_processed_prefix,
-                        snapshot,
-                    ),
-                    "s3_bucket": self.config.s3_bucket,
-                    "s3_prefix": self.config.s3_processed_prefix,
-                }
+                s3_ready_payload_json = build_s3_ready_payload(self.config, snapshot)
                 s3_ready_result = complete_parse_local_ready_and_archive_with_retry(
                     self.config,
                     claimed.job_id,
@@ -626,6 +807,272 @@ class ParseWorker:
                 claimed.job_id,
                 self.config.queue_name,
                 message.msg_id,
+                self.config.worker_id,
+                retryable,
+                str(exc),
+                "parse",
+            )
+
+
+class ParseSubmitterWorker:
+    def __init__(self, config: WorkerConfig):
+        self.config = config
+
+    def run_forever(self) -> None:
+        while True:
+            processed = self.run_once()
+            if not processed:
+                time.sleep(self.config.poll_interval_seconds)
+
+    def run_once(self) -> bool:
+        if not self.config.use_two_stage_parser:
+            raise RuntimeError("parse-submitter requires KB_PARSE_USE_TWO_STAGE=true")
+        try:
+            queue_status = fetch_two_stage_queue_status(
+                self.config.unstructure_serve_two_stage_base_url,
+                self.config.unstructure_serve_bearer_token,
+                timeout_seconds=self.config.two_stage_queue_status_timeout_seconds,
+            )
+        except Exception:
+            LOGGER.warning("could not fetch two-stage queue status; submitter is backing off", exc_info=True)
+            return False
+
+        backlog = queue_status.backlog(self.config.two_stage_parse_queue_name)
+        if backlog >= self.config.two_stage_max_parse_backlog:
+            LOGGER.info(
+                "two-stage parse backlog %s >= limit %s; submitter is backing off",
+                backlog,
+                self.config.two_stage_max_parse_backlog,
+            )
+            return False
+
+        message = read_queue_message(self.config, self.config.queue_name)
+        if message is None:
+            return False
+        self.process_message(message, queue_status.queues, queue_status.unacked)
+        return True
+
+    def process_message(
+        self,
+        message: queue.QueueMessage,
+        queues: dict[str, int],
+        unacked: dict[str, int],
+    ) -> None:
+        claimed = claim_queue_message(self.config, self.config.queue_name, message)
+        if claimed is None or not claimed.claimed:
+            return
+        if claimed.stage != "parse":
+            fail_job_and_archive_current_message(
+                self.config,
+                claimed.job_id,
+                self.config.queue_name,
+                message.msg_id,
+                self.config.worker_id,
+                False,
+                "UNSUPPORTED_STAGE",
+                "parse",
+            )
+            return
+
+        submitted = None
+        try:
+            snapshot = load_parse_snapshot_with_short_connection(self.config, claimed.job_id)
+            raw_path = resolve_raw_path(snapshot.raw_uri, self.config.nas_raw_root)
+            validate_raw_storage_path(snapshot, raw_path, self.config.nas_raw_root)
+            _validate_raw_file(raw_path, snapshot.file_size, snapshot.sha256)
+
+            submitted = submit_two_stage_task(
+                raw_path,
+                self.config.unstructure_serve_two_stage_base_url,
+                self.config.unstructure_serve_bearer_token,
+                timeout_seconds=self.config.two_stage_submit_timeout_seconds,
+                return_txt=True,
+                priority=self.config.two_stage_priority,
+                chunk_type=True,
+                provider=self.config.two_stage_provider,
+                model=self.config.two_stage_model,
+                prompt=self.config.two_stage_prompt,
+            )
+            registered = register_parse_two_stage_task_and_archive_with_retry(
+                self.config,
+                claimed.job_id,
+                submitted.task_id,
+                submitted.task_url,
+                submitted.status_url,
+                self.config.queue_name,
+                message.msg_id,
+                {
+                    "queues": queues,
+                    "unacked": unacked,
+                    "parse_queue": self.config.two_stage_parse_queue_name,
+                },
+            )
+            LOGGER.info(
+                "parse job %s submitted two-stage task %s document=%s status=%s",
+                claimed.job_id,
+                registered.task_id,
+                registered.document_id,
+                registered.document_status,
+            )
+        except Exception as exc:
+            LOGGER.exception("parse job %s two-stage submission failed", claimed.job_id)
+            if submitted is not None:
+                LOGGER.error(
+                    "parse job %s submitted two-stage task %s but did not persist registration",
+                    claimed.job_id,
+                    submitted.task_id,
+                )
+                return
+            retryable = is_parse_failure_retryable(exc)
+            fail_job_and_archive_current_message(
+                self.config,
+                claimed.job_id,
+                self.config.queue_name,
+                message.msg_id,
+                self.config.worker_id,
+                retryable,
+                str(exc),
+                "parse",
+            )
+
+
+class ParseFinalizerWorker:
+    def __init__(self, config: WorkerConfig):
+        self.config = config
+
+    def run_forever(self) -> None:
+        while True:
+            self.run_once()
+            time.sleep(self.config.poll_interval_seconds)
+
+    def run_once(self) -> bool:
+        if not self.config.use_two_stage_parser:
+            raise RuntimeError("parse-finalizer requires KB_PARSE_USE_TWO_STAGE=true")
+        processed = False
+        for _ in range(self.config.two_stage_finalizer_limit):
+            claimed = self.claim_next()
+            if claimed is None:
+                break
+            self.process_claim(claimed)
+            processed = True
+        return processed
+
+    def claim_next(self) -> control_plane.TwoStageFinalizationClaim | None:
+        with control_plane.connect(self.config.database_url) as conn:
+            return control_plane.claim_parse_two_stage_task(
+                conn,
+                self.config.worker_id,
+                self.config.lock_seconds,
+            )
+
+    def mark_state(
+        self,
+        job_id: str,
+        state: str,
+        error: str | None = None,
+    ) -> None:
+        with control_plane.connect(self.config.database_url) as conn:
+            ok = control_plane.mark_parse_two_stage_task_state(
+                conn,
+                job_id,
+                self.config.worker_id,
+                state,
+                error,
+                max(1, self.config.poll_interval_seconds * 2),
+            )
+        if not ok:
+            raise RuntimeError("mark_parse_two_stage_task_state returned false")
+
+    def process_claim(self, claimed: control_plane.TwoStageFinalizationClaim) -> None:
+        try:
+            try:
+                status = fetch_two_stage_task_status(
+                    self.config.unstructure_serve_two_stage_base_url,
+                    self.config.unstructure_serve_bearer_token,
+                    claimed.task_id,
+                    timeout_seconds=self.config.two_stage_status_timeout_seconds,
+                    return_txt=True,
+                )
+            except Exception as exc:
+                LOGGER.warning(
+                    "parse job %s two-stage task %s status poll failed; will retry",
+                    claimed.job_id,
+                    claimed.task_id,
+                    exc_info=True,
+                )
+                self.mark_state(claimed.job_id, "POLL_ERROR", str(exc))
+                return
+
+            if status.state in {"PENDING", "RECEIVED", "STARTED", "RETRY"}:
+                self.mark_state(claimed.job_id, status.state)
+                return
+            if status.state in {"FAILURE", "REVOKED"}:
+                error = status.error or status.state
+                self.mark_state(claimed.job_id, status.state, error)
+                raise ParserTaskFailure(f"parser two-stage task {claimed.task_id} failed: {error}")
+            if status.state != "SUCCESS" or status.parsed is None:
+                self.mark_state(claimed.job_id, status.state)
+                return
+
+            snapshot = load_parse_snapshot_with_short_connection(self.config, claimed.job_id)
+            deadline = JobDeadline("parse", self.config.parse_job_timeout_seconds)
+            if snapshot.processed_manifest_local_uri and snapshot.processed_artifact_uuid:
+                manifest_path = Path(snapshot.processed_manifest_local_uri)
+                artifact_info = load_artifact_info(
+                    manifest_path,
+                    snapshot.processed_manifest_hash,
+                )
+                manifest_local_uri = manifest_path.as_posix()
+                metadata_json = {
+                    "processed": {
+                        "parser_profile": artifact_info.manifest.get(
+                            "parser_profile",
+                            self.config.parser_profile,
+                        ),
+                        "parser_version": artifact_info.manifest.get(
+                            "parser_version",
+                            self.config.parser_version,
+                        ),
+                        "chunk_count": artifact_info.chunk_count,
+                        "artifact_uuid": artifact_info.artifact_uuid,
+                    }
+                }
+            else:
+                manifest_local_uri, artifact_info, metadata_json = (
+                    write_processed_artifacts_from_parsed(
+                        self.config,
+                        claimed.job_id,
+                        snapshot,
+                        status.parsed,
+                        deadline,
+                    )
+                )
+
+            result = complete_parse_local_ready_with_retry(
+                self.config,
+                claimed.job_id,
+                claimed.document_id,
+                claimed.document_version,
+                manifest_local_uri,
+                artifact_info.artifact_uuid,
+                artifact_info.manifest_hash,
+                artifact_info.chunk_count,
+                metadata_json,
+                build_s3_ready_payload(self.config, snapshot),
+            )
+            LOGGER.info(
+                "parse job %s finalized two-stage task %s and queued s3_ready job %s msg %s",
+                claimed.job_id,
+                claimed.task_id,
+                result.s3_ready_job_id,
+                result.s3_ready_msg_id,
+            )
+        except Exception as exc:
+            LOGGER.exception("parse job %s two-stage finalization failed", claimed.job_id)
+            retryable = is_parse_failure_retryable(exc)
+            fail_job_with_retry(
+                self.config,
+                claimed.job_id,
                 self.config.worker_id,
                 retryable,
                 str(exc),

--- a/tests/test_kb_parse_worker_reliability.py
+++ b/tests/test_kb_parse_worker_reliability.py
@@ -14,6 +14,7 @@ from src.kb_parse_worker.worker import (
     complete_s3_ready_check_and_archive_with_retry,
     complete_parse_local_ready_and_archive_with_retry,
     fail_job_and_archive_current_message,
+    handle_unclaimed_message,
     is_parse_failure_retryable,
     is_s3_ready_failure_retryable,
 )
@@ -120,132 +121,113 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
         self.assertTrue(is_s3_ready_failure_retryable(JobTimeout("S3_READY_JOB_TIMEOUT_AFTER_60s")))
 
     def test_parse_terminal_failure_marks_non_retryable_and_archives_dead_job(self) -> None:
-        conn = object()
-        fail_result = control_plane.FailJobResult(
-            job_id="job-1",
-            job_status="dead",
-            document_status="failed",
-        )
+        config = worker_config()
         with (
             patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
-            patch("src.kb_parse_worker.worker.control_plane.claim_job", return_value=claimed("parse")),
-            patch("src.kb_parse_worker.worker.load_parse_snapshot", side_effect=RuntimeError("EMPTY_RESULT")),
-            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+            patch("src.kb_parse_worker.worker.claim_queue_message", return_value=claimed("parse")),
+            patch(
+                "src.kb_parse_worker.worker.load_parse_snapshot_with_short_connection",
+                side_effect=RuntimeError("EMPTY_RESULT"),
+            ),
+            patch(
+                "src.kb_parse_worker.worker.fail_job_and_archive_current_message",
+            ) as fail_job,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
-            ParseWorker(worker_config()).process_message(conn, message())
+            ParseWorker(config).process_message(message())
 
         fail_job.assert_called_once()
-        self.assertFalse(fail_job.call_args.args[3])
-        archive.assert_called_once_with(conn, "kb_parse_queue", 1)
+        self.assertEqual(fail_job.call_args.args[1:5], ("job-1", "kb_parse_queue", 1, "worker-1"))
+        self.assertFalse(fail_job.call_args.args[5])
+        self.assertEqual(fail_job.call_args.args[7], "parse")
 
     def test_parse_timeout_marks_retryable_and_archives_current_message(self) -> None:
-        conn = object()
-        fail_result = control_plane.FailJobResult(
-            job_id="job-1",
-            job_status="failed",
-            document_status="parse_queued",
-        )
+        config = worker_config()
         with (
             patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
-            patch("src.kb_parse_worker.worker.control_plane.claim_job", return_value=claimed("parse")),
+            patch("src.kb_parse_worker.worker.claim_queue_message", return_value=claimed("parse")),
             patch(
-                "src.kb_parse_worker.worker.load_parse_snapshot",
+                "src.kb_parse_worker.worker.load_parse_snapshot_with_short_connection",
                 side_effect=JobTimeout("PARSE_JOB_TIMEOUT_AFTER_60s"),
             ),
-            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+            patch(
+                "src.kb_parse_worker.worker.fail_job_and_archive_current_message",
+            ) as fail_job,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
-            ParseWorker(worker_config()).process_message(conn, message())
+            ParseWorker(config).process_message(message())
 
         fail_job.assert_called_once()
-        self.assertTrue(fail_job.call_args.args[3])
-        archive.assert_called_once_with(conn, "kb_parse_queue", 1)
+        self.assertTrue(fail_job.call_args.args[5])
+        self.assertEqual(fail_job.call_args.args[7], "parse")
 
     def test_s3_ready_terminal_failure_marks_non_retryable_and_archives_dead_job(self) -> None:
-        conn = object()
-        fail_result = control_plane.FailJobResult(
-            job_id="job-1",
-            job_status="dead",
-            document_status="failed",
-        )
+        config = worker_config()
         with (
             patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch("src.kb_parse_worker.worker.claim_queue_message", return_value=claimed("s3_ready")),
             patch(
-                "src.kb_parse_worker.worker.control_plane.claim_job",
-                return_value=claimed("s3_ready"),
-            ),
-            patch(
-                "src.kb_parse_worker.worker.load_s3_ready_snapshot",
+                "src.kb_parse_worker.worker.load_s3_ready_snapshot_with_short_connection",
                 return_value=SimpleNamespace(processed_manifest_local_uri=None),
             ),
-            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+            patch(
+                "src.kb_parse_worker.worker.fail_job_and_archive_current_message",
+            ) as fail_job,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
-            S3ReadyWorker(worker_config()).process_message(conn, message())
+            S3ReadyWorker(config).process_message(message())
 
         fail_job.assert_called_once()
-        self.assertFalse(fail_job.call_args.args[3])
-        archive.assert_called_once()
+        self.assertEqual(fail_job.call_args.args[1:5], ("job-1", "kb_s3_ready_queue", 1, "worker-1"))
+        self.assertFalse(fail_job.call_args.args[5])
+        self.assertEqual(fail_job.call_args.args[7], "s3_ready")
 
     def test_s3_ready_transient_failure_marks_retryable_and_archives_current_message(self) -> None:
-        conn = object()
-        fail_result = control_plane.FailJobResult(
-            job_id="job-1",
-            job_status="failed",
-            document_status="s3_ready_check_failed",
-        )
+        config = worker_config()
         with (
             patch("src.kb_parse_worker.worker.LeaseMaintainer", NoopLease),
+            patch("src.kb_parse_worker.worker.claim_queue_message", return_value=claimed("s3_ready")),
             patch(
-                "src.kb_parse_worker.worker.control_plane.claim_job",
-                return_value=claimed("s3_ready"),
-            ),
-            patch(
-                "src.kb_parse_worker.worker.load_s3_ready_snapshot",
+                "src.kb_parse_worker.worker.load_s3_ready_snapshot_with_short_connection",
                 side_effect=RuntimeError("S3_NOT_READY_AFTER_TIMEOUT: sync delay"),
             ),
-            patch("src.kb_parse_worker.worker.control_plane.fail_job", return_value=fail_result) as fail_job,
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
+            patch(
+                "src.kb_parse_worker.worker.fail_job_and_archive_current_message",
+            ) as fail_job,
             patch("src.kb_parse_worker.worker.LOGGER.exception"),
         ):
-            S3ReadyWorker(worker_config()).process_message(conn, message())
+            S3ReadyWorker(config).process_message(message())
 
         fail_job.assert_called_once()
-        self.assertTrue(fail_job.call_args.args[3])
-        archive.assert_called_once_with(conn, "kb_s3_ready_queue", 1)
+        self.assertTrue(fail_job.call_args.args[5])
+        self.assertEqual(fail_job.call_args.args[7], "s3_ready")
 
     def test_parse_backoff_not_due_leaves_current_message_when_contract_says_keep(self) -> None:
         conn = object()
-        with (
-            patch(
-                "src.kb_parse_worker.worker.control_plane.claim_job",
-                return_value=claim_disposition("backoff_not_due", False),
-            ),
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
-        ):
-            ParseWorker(worker_config()).process_message(conn, message())
+        with patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive:
+            handle_unclaimed_message(
+                conn,
+                "kb_parse_queue",
+                message(),
+                claim_disposition("backoff_not_due", False),
+            )
 
         archive.assert_not_called()
 
     def test_parse_backoff_not_due_archives_current_message_when_contract_says_archive(self) -> None:
         conn = object()
-        with (
-            patch(
-                "src.kb_parse_worker.worker.control_plane.claim_job",
-                return_value=claim_disposition("backoff_not_due", True),
-            ),
-            patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive,
-        ):
-            ParseWorker(worker_config()).process_message(conn, message())
+        with patch("src.kb_parse_worker.worker.queue.archive_job_message_by_id", return_value=True) as archive:
+            handle_unclaimed_message(
+                conn,
+                "kb_parse_queue",
+                message(),
+                claim_disposition("backoff_not_due", True),
+            )
 
         archive.assert_called_once_with(conn, "kb_parse_queue", 1)
 
     def test_parse_finalization_reconnects_and_retries_db_connection_errors(self) -> None:
-        original_conn = FakeConnection("original")
+        first_conn = FakeConnection("first")
         retry_conn = FakeConnection("retry")
         result = control_plane.S3ReadyEnqueueResult(
             parse_job_id="job-1",
@@ -267,14 +249,16 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 "src.kb_parse_worker.worker.control_plane.complete_parse_local_ready_and_enqueue_s3_check",
                 side_effect=complete,
             ),
-            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch(
+                "src.kb_parse_worker.worker.control_plane.connect",
+                side_effect=[first_conn, retry_conn],
+            ) as connect,
             patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.time.sleep") as sleep,
             patch("src.kb_parse_worker.worker.LOGGER.warning"),
         ):
             actual = complete_parse_local_ready_and_archive_with_retry(
                 worker_config(),
-                original_conn,
                 "job-1",
                 "00000000-0000-0000-0000-000000000001",
                 1,
@@ -289,13 +273,13 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
             )
 
         self.assertEqual(actual, result)
-        self.assertEqual(calls, [original_conn, retry_conn])
-        connect.assert_called_once_with("postgresql://test")
+        self.assertEqual(calls, [first_conn, retry_conn])
+        self.assertEqual(connect.call_count, 2)
         sleep.assert_called_once_with(1.0)
         archive.assert_called_once_with(retry_conn, "kb_parse_queue", 1)
 
     def test_parse_finalization_does_not_retry_non_db_errors(self) -> None:
-        original_conn = FakeConnection("original")
+        first_conn = FakeConnection("first")
 
         with (
             patch(
@@ -304,14 +288,13 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                     "complete_parse_local_ready_and_enqueue_s3_check returned no row"
                 ),
             ) as complete,
-            patch("src.kb_parse_worker.worker.control_plane.connect") as connect,
+            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=first_conn) as connect,
             patch("src.kb_parse_worker.worker.archive_current_message") as archive,
             patch("src.kb_parse_worker.worker.time.sleep") as sleep,
         ):
             with self.assertRaisesRegex(RuntimeError, "returned no row"):
                 complete_parse_local_ready_and_archive_with_retry(
                     worker_config(),
-                    original_conn,
                     "job-1",
                     "00000000-0000-0000-0000-000000000001",
                     1,
@@ -326,12 +309,12 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 )
 
         complete.assert_called_once()
-        connect.assert_not_called()
+        connect.assert_called_once_with("postgresql://test")
         archive.assert_not_called()
         sleep.assert_not_called()
 
     def test_s3_ready_finalization_reconnects_and_retries_db_connection_errors(self) -> None:
-        original_conn = FakeConnection("original")
+        first_conn = FakeConnection("first")
         retry_conn = FakeConnection("retry")
         calls: list[FakeConnection] = []
 
@@ -346,14 +329,16 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
                 "src.kb_parse_worker.worker.control_plane.complete_s3_ready_check",
                 side_effect=complete,
             ),
-            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch(
+                "src.kb_parse_worker.worker.control_plane.connect",
+                side_effect=[first_conn, retry_conn],
+            ) as connect,
             patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.time.sleep") as sleep,
             patch("src.kb_parse_worker.worker.LOGGER.warning"),
         ):
             ok = complete_s3_ready_check_and_archive_with_retry(
                 worker_config(),
-                original_conn,
                 "job-1",
                 "00000000-0000-0000-0000-000000000001",
                 1,
@@ -367,13 +352,13 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
             )
 
         self.assertTrue(ok)
-        self.assertEqual(calls, [original_conn, retry_conn])
-        connect.assert_called_once_with("postgresql://test")
+        self.assertEqual(calls, [first_conn, retry_conn])
+        self.assertEqual(connect.call_count, 2)
         sleep.assert_called_once_with(1.0)
         archive.assert_called_once_with(retry_conn, "kb_s3_ready_queue", 1)
 
     def test_fail_job_reconnects_and_retries_db_connection_errors(self) -> None:
-        original_conn = FakeConnection("original")
+        first_conn = FakeConnection("first")
         retry_conn = FakeConnection("retry")
         result = control_plane.FailJobResult(
             job_id="job-1",
@@ -392,14 +377,16 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
 
         with (
             patch("src.kb_parse_worker.worker.control_plane.fail_job", side_effect=fail),
-            patch("src.kb_parse_worker.worker.control_plane.connect", return_value=retry_conn) as connect,
+            patch(
+                "src.kb_parse_worker.worker.control_plane.connect",
+                side_effect=[first_conn, retry_conn],
+            ) as connect,
             patch("src.kb_parse_worker.worker.archive_current_message", return_value=True) as archive,
             patch("src.kb_parse_worker.worker.time.sleep") as sleep,
             patch("src.kb_parse_worker.worker.LOGGER.warning"),
         ):
             actual = fail_job_and_archive_current_message(
                 worker_config(),
-                original_conn,
                 "job-1",
                 "kb_parse_queue",
                 1,
@@ -410,8 +397,8 @@ class KbParseWorkerReliabilityTests(unittest.TestCase):
             )
 
         self.assertEqual(actual, result)
-        self.assertEqual(calls, [original_conn, retry_conn])
-        connect.assert_called_once_with("postgresql://test")
+        self.assertEqual(calls, [first_conn, retry_conn])
+        self.assertEqual(connect.call_count, 2)
         sleep.assert_called_once_with(1.0)
         archive.assert_called_once_with(retry_conn, "kb_parse_queue", 1)
 


### PR DESCRIPTION
## Summary
- split the KB two-stage parse worker into submitter and finalizer modes
- add queue-status gating for queue_parse_gpu backlog before submitting Celery tasks
- add finalizer polling, processed artifact handoff, PM2 split-mode config, docs, and reliability test updates

## Validation
- ./.venv/bin/python -m compileall src/kb_parse_worker
- ./.venv/bin/python -m unittest discover -s tests -p 'test_kb_parse_worker*.py'
- docpact validate-config --root . --strict
- docpact lint --root . --worktree --detail compact
- git diff --check

Note: this branch also includes the earlier chunks_jsonl artifact fix commits that were already on the local branch.