### PR TITLE
Back off idle KB worker polling

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "2a94026defb263f98b423e2cdfceb1229f4c461b"
+lastReviewedAt: "2026-06-07"
+lastReviewedCommit: "4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f"
 
 repo:
   id: unstructure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # TianGong AI Unstructure Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # TianGong AI Unstructure

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Unstructure Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/**
   - docker/**
   - requirements.txt
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Unstructure Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,8 +13,8 @@ checkPaths:
   - .docpact/config.yaml
   - src/**
   - requirements.txt
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Unstructure Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -12,8 +12,8 @@ checkPaths:
   - requirements.txt
   - src/**
   - docker/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: eda42e5c0a485212b71a8aefc808574fa0bf013a
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Unstructure Development Runbook
@@ -228,6 +228,11 @@ fresh through `heartbeat_job(...)`. The worker defaults to:
 KB_PARSE_HEARTBEAT_INTERVAL_SECONDS=60
 KB_PARSE_JOB_TIMEOUT_SECONDS=7200
 ```
+
+When a long-running parse, parse-submitter, parse-finalizer, or S3-ready
+iteration finds no work, the worker backs off from `KB_PARSE_POLL_INTERVAL_SECONDS`
+exponentially up to 60 seconds. Any processed queue message or finalization
+claim resets the delay to the base interval.
 
 Raw and processed artifact paths are derived from the collection storage path.
 For example, collection path `/course/thu_humanities` resolves raw files under

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Unstructure Documentation Standards

--- a/src/journals/AGENTS.md
+++ b/src/journals/AGENTS.md
@@ -11,8 +11,8 @@ checkPaths:
   - src/journals/**
   - _docs/architecture/repo-architecture.md
   - _docs/runbooks/development.md
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a94026defb263f98b423e2cdfceb1229f4c461b
+lastReviewedAt: 2026-06-07
+lastReviewedCommit: 4f8b429b6eb1dc1b0bd9d6dda23da933441cdc8f
 ---
 
 # Journals Agent Notes

--- a/src/kb_parse_worker/worker.py
+++ b/src/kb_parse_worker/worker.py
@@ -37,6 +37,7 @@ from .snapshot import (
 LOGGER = logging.getLogger(__name__)
 FINALIZE_DB_MAX_ATTEMPTS = 3
 FINALIZE_DB_INITIAL_BACKOFF_SECONDS = 1.0
+IDLE_POLL_MAX_SECONDS = 60
 
 
 class JobTimeout(RuntimeError):
@@ -120,6 +121,26 @@ def is_s3_ready_failure_retryable(error: Exception) -> bool:
         return False
 
     return True
+
+
+def _idle_poll_delay_seconds(config: WorkerConfig, idle_iterations: int) -> int:
+    base = max(1, int(config.poll_interval_seconds))
+    max_interval = max(base, getattr(config, "idle_poll_interval_max_seconds", IDLE_POLL_MAX_SECONDS))
+    multiplier = 2 ** max(0, idle_iterations - 1)
+    return min(max_interval, base * multiplier)
+
+
+def _run_forever_with_idle_backoff(config: WorkerConfig, run_once) -> None:
+    idle_iterations = 0
+
+    while True:
+        processed = run_once()
+        if processed:
+            idle_iterations = 0
+            continue
+
+        idle_iterations += 1
+        time.sleep(_idle_poll_delay_seconds(config, idle_iterations))
 
 
 def archive_current_message(conn, queue_name: str, msg_id: int) -> bool:
@@ -680,10 +701,7 @@ class ParseWorker:
         self.config = config
 
     def run_forever(self) -> None:
-        while True:
-            processed = self.run_once()
-            if not processed:
-                time.sleep(self.config.poll_interval_seconds)
+        _run_forever_with_idle_backoff(self.config, self.run_once)
 
     def run_once(self) -> bool:
         message = read_queue_message(self.config, self.config.queue_name)
@@ -819,10 +837,7 @@ class ParseSubmitterWorker:
         self.config = config
 
     def run_forever(self) -> None:
-        while True:
-            processed = self.run_once()
-            if not processed:
-                time.sleep(self.config.poll_interval_seconds)
+        _run_forever_with_idle_backoff(self.config, self.run_once)
 
     def run_once(self) -> bool:
         if not self.config.use_two_stage_parser:
@@ -941,9 +956,7 @@ class ParseFinalizerWorker:
         self.config = config
 
     def run_forever(self) -> None:
-        while True:
-            self.run_once()
-            time.sleep(self.config.poll_interval_seconds)
+        _run_forever_with_idle_backoff(self.config, self.run_once)
 
     def run_once(self) -> bool:
         if not self.config.use_two_stage_parser:
@@ -1085,10 +1098,7 @@ class S3ReadyWorker:
         self.config = config
 
     def run_forever(self) -> None:
-        while True:
-            processed = self.run_once()
-            if not processed:
-                time.sleep(self.config.poll_interval_seconds)
+        _run_forever_with_idle_backoff(self.config, self.run_once)
 
     def run_once(self) -> bool:
         message = read_queue_message(self.config, self.config.s3_ready_queue_name)

--- a/tests/test_kb_parse_worker_reliability.py
+++ b/tests/test_kb_parse_worker_reliability.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import psycopg2
 
@@ -101,6 +101,42 @@ class FakeConnection:
 
 
 class KbParseWorkerReliabilityTests(unittest.TestCase):
+    def test_idle_poll_backs_off_and_caps(self) -> None:
+        config = worker_config()
+        config.poll_interval_seconds = 1
+        config.idle_poll_interval_max_seconds = 4
+        worker = ParseWorker(config)
+
+        with (
+            patch.object(worker, "run_once", return_value=False),
+            patch(
+                "src.kb_parse_worker.worker.time.sleep",
+                side_effect=[None, None, None, KeyboardInterrupt],
+            ) as sleep,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                worker.run_forever()
+
+        self.assertEqual(sleep.call_args_list, [call(1), call(2), call(4), call(4)])
+
+    def test_idle_poll_resets_after_processed_work(self) -> None:
+        config = worker_config()
+        config.poll_interval_seconds = 1
+        config.idle_poll_interval_max_seconds = 4
+        worker = ParseWorker(config)
+
+        with (
+            patch.object(worker, "run_once", side_effect=[False, False, True, False]),
+            patch(
+                "src.kb_parse_worker.worker.time.sleep",
+                side_effect=[None, None, KeyboardInterrupt],
+            ) as sleep,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                worker.run_forever()
+
+        self.assertEqual(sleep.call_args_list, [call(1), call(2), call(1)])
+
     def test_parse_failure_classifier_distinguishes_terminal_and_transient(self) -> None:
         self.assertFalse(is_parse_failure_retryable(RuntimeError("EMPTY_RESULT")))
         self.assertFalse(is_parse_failure_retryable(RuntimeError("RAW_STORAGE_PATH_MISMATCH: path")))


### PR DESCRIPTION
## Summary

- add a shared idle-backoff loop for the KB parse pipeline workers
- apply it to parse, submitter, finalizer, and S3-ready loops
- cap consecutive idle polling at 60 seconds and reset after work
- add reliability tests and refresh governed documentation

Closes #34

## Validation

- `PYTHONPATH=. uv run pytest tests/test_kb_parse_worker_reliability.py` — 14 passed
- `uv run python -m compileall src/kb_parse_worker` — passed
- `docpact validate-config --root . --strict` — passed
- `docpact lint --worktree --mode enforce` — passed

## Risk / rollback

Active work remains on the configured base interval. Revert this PR to restore fixed-interval idle polling.

